### PR TITLE
38 홈 전체 게시글 시음기록 feed 리스트 조회

### DIFF
--- a/repo/beans/views.py
+++ b/repo/beans/views.py
@@ -5,7 +5,7 @@ from drf_spectacular.utils import extend_schema, OpenApiParameter
 
 from repo.beans.models import Bean
 from repo.beans.serializers import BeanSerializer
-from repo.records.serializers import PageNumberSerializer
+from repo.common.serializers import PageNumberSerializer
 
 
 @extend_schema(

--- a/repo/common/serializers.py
+++ b/repo/common/serializers.py
@@ -1,0 +1,18 @@
+from rest_framework import serializers
+
+from repo.records.models import Photo
+
+
+class PageNumberSerializer(serializers.Serializer):
+    page = serializers.IntegerField(min_value=1, default=1)
+
+    def validate_page(self, value):
+        if value < 1:
+            raise serializers.ValidationError("Page number must be a positive integer.")
+        return value
+
+
+class PhotoSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Photo
+        fields = ["photo_url"]

--- a/repo/records/posts/serializers.py
+++ b/repo/records/posts/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from repo.profiles.serializers import UserSimpleSerializer
 from repo.records.models import Post, TastedRecord
-from repo.records.serializers import PhotoSerializer
+from repo.common.serializers import PhotoSerializer
 from repo.records.tasted_record.serializers import TastedRecordListSerializer,TastedRecordInPostSerializer
 
 

--- a/repo/records/posts/views.py
+++ b/repo/records/posts/views.py
@@ -11,7 +11,7 @@ from repo.common.utils import get_object, delete
 from repo.common.view_counter import update_view_count
 from repo.records.models import Photo
 from repo.records.posts.serializers import *
-from repo.records.serializers import PageNumberSerializer
+from repo.common.serializers import PageNumberSerializer
 from repo.records.services import get_post_detail, get_post_feed2
 
 

--- a/repo/records/serializers.py
+++ b/repo/records/serializers.py
@@ -1,39 +1,17 @@
-import importlib
-
 from rest_framework import serializers
 
+from repo.records.posts.serializers import PostListSerializer
+from repo.records.tasted_record.serializers import TastedRecordListSerializer
 from repo.profiles.serializers import UserSimpleSerializer
-from repo.records.models import Comment, Note, Photo, Post, TastedRecord
-
-
-class PhotoSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Photo
-        fields = ["photo_url"]
-
-
-class PageNumberSerializer(serializers.Serializer):
-    page = serializers.IntegerField(min_value=1, default=1)
-
-    def validate_page(self, value):
-        if value < 1:
-            raise serializers.ValidationError("Page number must be a positive integer.")
-        return value
+from repo.records.models import Comment, Note, Post, TastedRecord
 
 
 class FeedSerializer(serializers.ModelSerializer):
-
     def to_representation(self, instance):
-        # 순환 참조 피하기 위함
-        post_serializer_module = importlib.import_module("repo.records.posts.serializers")
-        tasted_record_serializer_module = importlib.import_module("repo.records.tasted_record.serializers")
-        PostFeedSerializer = getattr(post_serializer_module, "PostFeedSerializer")
-        TastedRecordFeedSerializer = getattr(tasted_record_serializer_module, "TastedRecordFeedSerializer")
-
         if isinstance(instance, Post):
-            return PostFeedSerializer(instance).data
+            return PostListSerializer(instance).data
         elif isinstance(instance, TastedRecord):
-            return TastedRecordFeedSerializer(instance).data
+            return TastedRecordListSerializer(instance).data
         return super().to_representation(instance)
 
 

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -1,3 +1,4 @@
+import random
 from datetime import timedelta
 from itertools import chain
 
@@ -9,81 +10,125 @@ from django.utils import timezone
 from repo.common.view_counter import is_viewed
 from repo.profiles.models import Relationship
 from repo.records.models import Comment, Photo, Post, TastedRecord
-
-# TODO
-# - user 인자를 받아서 팔로우한 사용자의 시음 기록만 가져오기(추후 이것으로 변경)
-# - 차단한 사용자의 시음 기록은 가져오지 않기
+from repo.records.posts.serializers import PostListSerializer
+from repo.records.tasted_record.serializers import TastedRecordListSerializer
 
 
-def get_following_feed(user, page=1):
+def get_serialized_data(page_obj):
+    """
+    페이지 객체를 받아 시리얼라이즈된 데이터를 반환하는 함수
+    게시글 리스트 or 시음기록 리스트
+    """
+    return [
+        TastedRecordListSerializer(item).data if isinstance(item, TastedRecord) else PostListSerializer(item).data
+        for item in page_obj.object_list
+    ]
 
+def get_following_feed(request, user):
+    """
+    사용자가 팔로잉한 유저들의 1시간 이내 작성한 시음기록과 게시글을 랜덤순으로 가져오는 함수
+    30분이내 조회한 기록, 프라이빗한 시음기록은 제외
+    """
     following_users = Relationship.custom_objects.following(user.id).values_list("to_user", flat=True)
     one_hour_ago = timezone.now() - timedelta(hours=1)
 
-    following_Tasted_Record = (
-        TastedRecord.objects.filter(author__in=following_users, is_private=False, created_at__gte=one_hour_ago)
+    following_tasted_record = (  # author__in=following_users,
+        TastedRecord.objects.filter(is_private=False, created_at__gte=one_hour_ago)
+        .select_related("author", "bean", "taste_review")
+        .prefetch_related(Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
+        .order_by("-id")
+    )
+
+    following_post = (  # author__in=following_users,
+        Post.objects.filter(created_at__gte=one_hour_ago)
+        .select_related("author")
+        .prefetch_related("tasted_records", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
+        .order_by("-id")
+    )
+
+    # 30분 이내 조회한 시음 기록 제외
+    not_viewed_tasted_record = [
+        record for record in following_tasted_record
+        if not is_viewed(request, cookie_name="tasted_record_viewed", content_id=record.id)
+    ]
+
+    # 30분 이내 조회한 게시글 제외
+    not_viewed_post = [
+        post for post in following_post
+        if not is_viewed(request, cookie_name="post_viewed", content_id=post.id)
+    ]
+
+    # 두 쿼리셋 결합
+    combined_data = list(chain(not_viewed_tasted_record, not_viewed_post))
+    random.shuffle(combined_data)
+
+    return combined_data
+
+
+def get_common_feed(request, user):
+    """
+    일반 시음기록과 게시글을 최신순으로 가져오는 함수
+    30분이내 조회한 기록, 프라이빗한 시음기록은 제외
+    팔로잉한 유저 기록 제외
+    """
+    following_users = Relationship.custom_objects.following(user.id).values_list("to_user", flat=True)
+
+    common_tasted_record = (
+        TastedRecord.objects.filter(is_private=False)
+        .exclude(author__in=following_users)
         .select_related("author", "bean", "taste_review")
         .prefetch_related(Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
         .order_by("-created_at")
     )
 
-    following_Post = (
-        Post.objects.filter(author__in=following_users, created_at__gte=one_hour_ago)
+    common_post = (
+        Post.objects
+        .exclude(author__in=following_users)
         .select_related("author")
         .prefetch_related("tasted_records", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
         .order_by("-created_at")
     )
 
-    # 각각 페이징 처리
-    paginator_Tasted_Record = Paginator(following_Tasted_Record, 5)
-    paginator_Post = Paginator(following_Post, 5)
+    not_viewed_tasted_record = [
+        record for record in common_tasted_record
+        if not is_viewed(request, cookie_name="tasted_record_viewed", content_id=record.id)
+    ]
 
-    # 페이지 가져오기
-    page_obj_Tasted_Record = paginator_Tasted_Record.get_page(page)
-    page_obj_Post = paginator_Post.get_page(page)
+    not_viewed_post = [
+        post for post in common_post
+        if not is_viewed(request, cookie_name="post_viewed", content_id=post.id)
+    ]
 
-    # 페이지 결합
-    all_records = list(chain(page_obj_Tasted_Record.object_list, page_obj_Post.object_list))
-    all_records = sorted(all_records, key=lambda x: x.created_at, reverse=True)
+    combined_data = sorted(
+        chain(not_viewed_tasted_record, not_viewed_post), key=lambda x: x.created_at, reverse=True
+    )
 
-    has_next = page_obj_Tasted_Record.has_next() or page_obj_Post.has_next()
+    return combined_data
 
-    return all_records, has_next
+def get_refresh_feed():
+    """
+    시음기록과 게시글을 랜덤순으로 가져오는 함수
+    프라이빗한 시음기록은 제외
+    """
 
-
-def get_common_feed(user, page=1, last_id=None):
-
-    one_hour_ago = timezone.now() - timedelta(hours=1)
-
-    following_Tasted_Record = (
-        TastedRecord.objects.filter(is_private=False, created_at__gte=one_hour_ago, id__gt=last_id)
+    tasted_records = (
+        TastedRecord.objects.filter(is_private=False)
         .select_related("author", "bean", "taste_review")
         .prefetch_related(Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
-        .order_by("-created_at")
+        .order_by("?")
     )
 
-    following_Post = (
-        Post.objects.filter(created_at__gte=one_hour_ago, id__gt=last_id)
+    posts = (
+        Post.objects
         .select_related("author")
         .prefetch_related("tasted_records", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
-        .order_by("-created_at")
+        .order_by("?")
     )
 
-    # 각각 페이징 처리
-    paginator_Tasted_Record = Paginator(following_Tasted_Record, 5)
-    paginator_Post = Paginator(following_Post, 5)
+    combined_data = list(chain(tasted_records, posts))
+    random.shuffle(combined_data)
 
-    # 페이지 가져오기
-    page_obj_Tasted_Record = paginator_Tasted_Record.get_page(page)
-    page_obj_Post = paginator_Post.get_page(page)
-
-    # 페이지 결합
-    all_records = list(chain(page_obj_Tasted_Record.object_list, page_obj_Post.object_list))
-    all_records = sorted(all_records, key=lambda x: x.created_at, reverse=True)
-
-    has_next = page_obj_Tasted_Record.has_next() or page_obj_Post.has_next()
-
-    return all_records, has_next
+    return combined_data
 
 
 def get_tasted_record_feed(user):
@@ -147,8 +192,7 @@ def get_post_feed(user, page=1):
 
     if not following_users.exists() or followed_posts.count() < 10:
         additional_posts = (
-            Post.objects.filter(is_private=False)
-            .exclude(author__in=following_users)
+            Post.objects.exclude(author__in=following_users)
             .select_related("author", "taste_and_review")
             .prefetch_related(Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
             .order_by("-created_at")

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -32,15 +32,15 @@ def get_following_feed(request, user):
     following_users = Relationship.custom_objects.following(user.id).values_list("to_user", flat=True)
     one_hour_ago = timezone.now() - timedelta(hours=1)
 
-    following_tasted_record = (  # author__in=following_users,
-        TastedRecord.objects.filter(is_private=False, created_at__gte=one_hour_ago)
+    following_tasted_record = (
+        TastedRecord.objects.filter(author__in=following_users, is_private=False, created_at__gte=one_hour_ago)
         .select_related("author", "bean", "taste_review")
         .prefetch_related(Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
         .order_by("-id")
     )
 
-    following_post = (  # author__in=following_users,
-        Post.objects.filter(created_at__gte=one_hour_ago)
+    following_post = (
+        Post.objects.filter(author__in=following_users, created_at__gte=one_hour_ago)
         .select_related("author")
         .prefetch_related("tasted_records", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
         .order_by("-id")

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -6,6 +6,7 @@ from django.db.models import Prefetch
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 
+from repo.common.view_counter import is_viewed
 from repo.profiles.models import Relationship
 from repo.records.models import Comment, Photo, Post, TastedRecord
 

--- a/repo/records/tasted_record/serializers.py
+++ b/repo/records/tasted_record/serializers.py
@@ -4,7 +4,7 @@ from repo.beans.models import Bean, BeanTasteReview
 from repo.beans.serializers import BeanSerializer, BeanTasteReviewSerializer
 from repo.profiles.serializers import UserSimpleSerializer
 from repo.records.models import TastedRecord
-from repo.records.serializers import PhotoSerializer
+from repo.common.serializers import PhotoSerializer
 
 
 class TastedRecordListSerializer(serializers.ModelSerializer):

--- a/repo/records/tasted_record/views.py
+++ b/repo/records/tasted_record/views.py
@@ -13,7 +13,7 @@ from repo.beans.models import Bean, BeanTasteReview
 from repo.common.utils import delete, get_object
 from repo.common.view_counter import update_view_count
 from repo.records.models import TastedRecord, Photo
-from repo.records.serializers import PageNumberSerializer
+from repo.common.serializers import PageNumberSerializer
 from repo.records.services import get_tasted_record_detail, get_tasted_record_feed
 from repo.records.tasted_record.serializers import (
     TastedRecordDetailSerializer,

--- a/repo/records/urls.py
+++ b/repo/records/urls.py
@@ -5,9 +5,7 @@ from repo.records import views
 urlpatterns = [
     path("post/", include("repo.records.posts.urls")),
     path("tasted_record/", include("repo.records.tasted_record.urls")),
-    path("feed/follow/", views.FollowFeedAPIView.as_view(), name="feed-follow"),
-    path("feed/common/", views.CommonFeedAPIView.as_view(), name="feed-common"),
-    path("feed/refresh/", views.RefreshFeedAPIView.as_view(), name="feed-refresh"),
+    path("feed/", views.FeedAPIView.as_view(), name="feed"),
     path("like", views.LikeApiView.as_view(), name="records-likes"),
     path("comment/<int:id>", views.CommentDetailAPIView.as_view(), name="comment-detail"),
     path("comment/<str:object_type>/<int:object_id>", views.CommentApiView.as_view(), name="comment-list"),

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -12,6 +12,7 @@ from repo.records.serializers import (
     NoteSerializer,
     PageNumberSerializer,
 )
+from repo.common.serializers import PageNumberSerializer
 from repo.records.services import (
     get_comment,
     get_comment_list,

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -1,16 +1,16 @@
 from django.shortcuts import get_object_or_404
+from django.core.paginator import Paginator
+from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from repo.common.utils import delete, update
-from repo.common.view_counter import is_viewed
 from repo.records.models import Comment, Note, Post, TastedRecord
+from repo.records.posts.serializers import PostListSerializer
 from repo.records.serializers import (
     CommentSerializer,
-    FeedSerializer,
     NoteSerializer,
-    PageNumberSerializer,
 )
 from repo.common.serializers import PageNumberSerializer
 from repo.records.services import (
@@ -18,106 +18,114 @@ from repo.records.services import (
     get_comment_list,
     get_common_feed,
     get_following_feed,
-    get_post_or_tasted_record_detail,
+    get_post_or_tasted_record_detail, get_refresh_feed, get_serialized_data,
 )
+from repo.records.tasted_record.serializers import TastedRecordListSerializer
 
 
 class FollowFeedAPIView(APIView):
-    """
-    홈 [전체] - 팔로워들의 게시글+시음기록 리스트를 반환하는 API
-    Args:
-        - page : 조회할 페이지 번호
-    Returns:
-        - status: 200
-
-    주의:
-        - 팔로잉하는 사용자들의 기록 우선 노출 (팔로잉 O, 조회 X) (최신순)
-
-    담당자: hwstar1204
-    """
-
+    @extend_schema(
+        parameters=[PageNumberSerializer],
+        responses=[TastedRecordListSerializer, PostListSerializer],
+        summary="홈 [전체] - 팔로잉 피드",
+        description="""
+            홈 [전체] 사용자가 팔로잉한 유저들의 1시간 이내 작성한 시음기록과 게시글을 랜덤순으로 가져오는 함수
+            30분이내 조회한 기록, 프라이빗한 시음기록은 제외
+            
+            담당자 : hwstar1204
+        """,
+        tags=["Feed"],
+    )
     def get(self, request):
         page_serializer = PageNumberSerializer(data=request.GET)
-        if page_serializer.is_valid():
-            page = page_serializer.validated_data["page"]
-        else:
+        if not page_serializer.is_valid():
             return Response(page_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+        page = page_serializer.validated_data["page"]
         user = request.user
-        feed_items, has_next = get_following_feed(user, page)
 
-        results = []
-        for item in feed_items:
-            if not is_viewed(request, cookie_name="records_viewed", content_id=id):
-                results.append(item)
+        combined_data = get_following_feed(request, user)
 
-        post_serializer = FeedSerializer(results, many=True)
-        return Response({"records": post_serializer.data, "has_next": has_next}, status=status.HTTP_200_OK)
+        paginator = Paginator(combined_data, 12)
+        page_obj = paginator.get_page(page)
+
+        serialized_data = get_serialized_data(page_obj)
+
+        return Response({
+            "results": serialized_data,
+            "has_next": page_obj.has_next(),
+            "current_page": page_obj.number,
+        }, status=status.HTTP_200_OK)
 
 
 class CommonFeedAPIView(APIView):
-    """
-    홈 [전체] - 일반 게시글+시음기록 리스트를 반환하는 API
-    Args:
-        - page : 조회할 페이지 번호
-    Returns:
-        - status: 200
-
-    주의:
-        - 일반 사용자들의 기록 노출  (팔로잉X, 조회 X) (최신순)
-
-    담당자: hwstar1204
-    """
-
+    @extend_schema(
+        parameters=[PageNumberSerializer],
+        responses=[TastedRecordListSerializer, PostListSerializer],
+        summary="홈 [전체] - 일반 피드",
+        description="""
+            홈 [전체] 일반 시음기록과 게시글을 최신순으로 가져오는 함수
+            30분이내 조회한 기록, 프라이빗한 시음기록은 제외
+            
+            담당자 : hwstar1204
+        """,
+        tags=["Feed"],
+    )
     def get(self, request):
         page_serializer = PageNumberSerializer(data=request.GET)
-        if page_serializer.is_valid():
-            page = page_serializer.validated_data["page"]
-        else:
+        if not page_serializer.is_valid():
             return Response(page_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
+        page = page_serializer.validated_data["page"]
         user = request.user
-        feed_items, has_next = get_common_feed(user, page)
 
-        results = []
-        for item in feed_items:
-            if not is_viewed(request, cookie_name="records_viewed", content_id=id):
-                results.append(item)
+        combined_data = get_common_feed(request, user)
 
-        post_serializer = FeedSerializer(results, many=True)
-        return Response({"records": post_serializer.data, "has_next": has_next}, status=status.HTTP_200_OK)
+        paginator = Paginator(combined_data, 12)
+        page_obj = paginator.get_page(page)
+
+        serialized_data = get_serialized_data(page_obj)
+
+        return Response({
+            "results": serialized_data,
+            "has_next": page_obj.has_next(),
+            "current_page": page_obj.number,
+        }, status=status.HTTP_200_OK)
 
 
 class RefreshFeedAPIView(APIView):
-    """
-    홈 [전체] - 사용자가 마지막으로 본 게시물 이후 데이터 반환하는 API
-    Args:
-        - last_id : 사용자가 마지막으로 본 게시물의 ID
-        - page : 조회할 페이지 번호
-    Returns:
-        - status: 200
-
-    담당자: hwstar1204
-    """
+    @extend_schema(
+        parameters=[PageNumberSerializer],
+        responses=[TastedRecordListSerializer, PostListSerializer],
+        summary="홈 [전체] 새로고침 피드",
+        description="""
+            홈 [전체] 시음기록과 게시글을 랜덤순으로 반환하는 API
+            프라이빗한 시음기록은 제외
+            
+            담당자 : hwstar1204
+        """,
+        tags=["Feed"],
+    )
 
     def get(self, request):
-        last_id = request.GET.get("last_id")
         page_serializer = PageNumberSerializer(data=request.GET)
-        if page_serializer.is_valid():
-            page = page_serializer.validated_data["page"]
-        else:
+        if not page_serializer.is_valid():
             return Response(page_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-        user = request.user
-        feed_items, has_next = get_common_feed(user, page, last_id)
+        page = page_serializer.validated_data["page"]
 
-        results = []
-        for item in feed_items:
-            if not is_viewed(request, cookie_name="records_viewed", content_id=id):
-                results.append(item)
+        combined_data = get_refresh_feed()
 
-        post_serializer = FeedSerializer(results, many=True)
-        return Response({"records": post_serializer.data, "has_next": has_next}, status=status.HTTP_200_OK)
+        paginator = Paginator(combined_data, 12)
+        page_obj = paginator.get_page(page)
+
+        serialized_data = get_serialized_data(page_obj)
+
+        return Response({
+            "results": serialized_data,
+            "has_next": page_obj.has_next(),
+            "current_page": page_obj.number,
+        }, status=status.HTTP_200_OK)
 
 
 class LikeApiView(APIView):


### PR DESCRIPTION
## #️⃣연관된 이슈

> #32 #38  

## 📝작업 내용

**1. 시리얼라이저 구조 개선**

- 공통적으로 사용되는 시리얼라이저를 repo.common.serializers **모듈**로 이동.
- PageNumberSerializer: repo.beans.views.py에서 가져오도록 수정.
- PhotoSerializer: repo.records.posts.serializers.py와 repo.records.tasted_record.serializers.py에서 공통 모듈로 변경.

**2. 피드 조회 로직 리팩토링**

**피드 로직을 서비스 계층(repo/records/services.py)** 으로 이동해 코드 재사용성 강화.

- **새로운 함수 추가**:
    - get_serialized_data: 객체를 적절한 시리얼라이저로 변환.
    - get_following_feed: 팔로잉 유저들의 최근 시음기록과 게시글 가져오기.
    - get_common_feed: 팔로잉하지 않은 유저들의 최신 콘텐츠 가져오기.
    - get_refresh_feed: 모든 콘텐츠를 랜덤으로 가져오기.

**3. 뷰 통합 및 개선**

- **FollowFeedAPIView, CommonFeedAPIView, RefreshFeedAPIView**를 하나의 **FeedAPIView**로 통합.
    - feed_type 쿼리 파라미터를 사용해 요청된 피드 타입을 처리.
    - **Paginator**로 페이지네이션 처리.
    - get_serialized_data 함수로 시리얼라이즈된 데이터를 반환하도록 개선.

**4. URL 패턴 변경**

- **repo/records/urls.py**에서 **통합된 FeedAPIView**를 사용하도록 URL 패턴 업데이트.