### PR TITLE
59 사용자가 작성한 시음기록 리스트 조회

### DIFF
--- a/config/settings/_base.py
+++ b/config/settings/_base.py
@@ -37,6 +37,7 @@ THIRD_PARTY_APPS = [
     "allauth.socialaccount.providers.naver",
     "drf_spectacular",  # swagger
     "storages",  # s3
+    "django_filters",  # filtering
 ]
 
 INSTALLED_APPS = [

--- a/config/settings/_base.py
+++ b/config/settings/_base.py
@@ -69,7 +69,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework_simplejwt.authentication.JWTAuthentication",),
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
-    "PAGE_SIZE": 5,
+    "PAGE_SIZE": 12,
 }
 
 REST_AUTH = {

--- a/poetry.lock
+++ b/poetry.lock
@@ -504,6 +504,20 @@ docs = ["furo (>=2021.8.17b43,<2021.9.dev0)", "sphinx (>=3.5.0)", "sphinx-notfou
 testing = ["coverage[toml] (>=5.0a4)", "pytest (>=4.6.11)"]
 
 [[package]]
+name = "django-filter"
+version = "24.3"
+description = "Django-filter is a reusable Django application for allowing users to filter querysets dynamically."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "django_filter-24.3-py3-none-any.whl", hash = "sha256:c4852822928ce17fb699bcfccd644b3574f1a2d80aeb2b4ff4f16b02dd49dc64"},
+    {file = "django_filter-24.3.tar.gz", hash = "sha256:d8ccaf6732afd21ca0542f6733b11591030fa98669f8d15599b358e24a2cd9c3"},
+]
+
+[package.dependencies]
+Django = ">=4.2"
+
+[[package]]
 name = "django-storages"
 version = "1.14.4"
 description = "Support for many storage backends in Django"
@@ -1365,4 +1379,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "d38ee6190109445b7c3ea0fa44e1f998ea3cfb9826f07c81a6fa8979668c1bcc"
+content-hash = "76221e2bbd8e1a1fd1058e594fa54f3f10b40b920c074f19e96aa0b17f972c3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ pillow = "^10.4.0"
 pymysql = "^1.1.1"
 gunicorn = "^23.0.0"
 cryptography = "^43.0.1"
+django-filter = "^24.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/repo/common/utils.py
+++ b/repo/common/utils.py
@@ -119,3 +119,18 @@ def get_time_difference(object_created_at: timezone) -> str:
     if (minutes_ago := (time_difference % timedelta(hours=1)) // timedelta(minutes=1)) > 0:
         return f"{minutes_ago}분 전"
     return "방금 전"
+
+
+def get_first_photo_url(obj: Model) -> Optional[str]:
+    """
+    주어진 객체의 첫 번째 사진 URL을 반환
+    Args:
+        obj: 사진 URL을 가져올 객체
+    Returns:
+        str: 객체의 첫 번째 사진 URL
+    작성자 : hwstar1204
+    """
+
+    if obj and hasattr(obj, "photo_set") and obj.photo_set.exists():
+        return obj.photo_set.first().photo_url.url
+    return None

--- a/repo/profiles/urls.py
+++ b/repo/profiles/urls.py
@@ -20,4 +20,5 @@ urlpatterns = [
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("<int:id>/posts/", views.UserPostListAPIView.as_view(), name="user_posts"),
+    path("<int:id>/tasted-records/", views.UserTastedRecordListView.as_view(), name="user_tasted_records"),
 ]

--- a/repo/records/filters.py
+++ b/repo/records/filters.py
@@ -1,0 +1,15 @@
+from django_filters import rest_framework as filters
+
+from repo.records.models import TastedRecord
+
+
+class TastedRecordFilter(filters.FilterSet):
+    bean_type = filters.ChoiceFilter(field_name="bean__bean_type", choices=[("single", "single"), ("blend", "blend")])
+    origin_country = filters.CharFilter(field_name="bean__origin_country", lookup_expr="icontains")
+    star_min = filters.NumberFilter(field_name="taste_review__star", lookup_expr="gte")
+    star_max = filters.NumberFilter(field_name="taste_review__star", lookup_expr="lte")
+    is_decaf = filters.BooleanFilter(field_name="bean__is_decaf")
+
+    class Meta:
+        model = TastedRecord
+        fields = ["bean_type", "origin_country", "star_min", "star_max", "is_decaf"]

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -256,3 +256,12 @@ def get_user_posts_by_subject(user, subject):
     )
 
     return posts
+
+
+def get_user_tasted_records_by_filter(user):
+    """사용자가 작성한 주제별 시음기록 리스트를 가져오는 함수"""
+
+    queryset = user.tastedrecord_set.select_related("author", "bean", "taste_review").prefetch_related(
+        Prefetch("photo_set", queryset=Photo.objects.only("photo_url"))
+    )
+    return queryset

--- a/repo/records/tasted_record/serializers.py
+++ b/repo/records/tasted_record/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from repo.beans.serializers import BeanSerializer, BeanTasteReviewSerializer
 from repo.common.serializers import PhotoSerializer
+from repo.common.utils import get_first_photo_url
 from repo.profiles.serializers import UserSimpleSerializer
 from repo.records.models import Photo, TastedRecord
 
@@ -86,3 +87,16 @@ class TastedRecordInPostSerializer(serializers.ModelSerializer):
     class Meta:
         model = TastedRecord
         fields = ["id", "content", "bean_name", "bean_type", "star_rating", "flavor", "photos"]
+
+
+class UserTastedRecordSerializer(serializers.ModelSerializer):
+    bean_name = serializers.CharField(source="bean.name")
+    star = serializers.FloatField(source="taste_review.star")
+    photo_url = serializers.SerializerMethodField()
+
+    def get_photo_url(self, obj):
+        return get_first_photo_url(obj)
+
+    class Meta:
+        model = TastedRecord
+        fields = ["id", "bean_name", "star", "photo_url"]


### PR DESCRIPTION
## #️⃣연관된 이슈

> #59 

## 📝작업 내용

이번 Pull Request에서는 설정 파일, 유틸리티 함수, API 엔드포인트, 시리얼라이저 등을 포함한 코드베이스 전반에 걸친 여러 가지 개선 사항과 새로운 기능이 추가되었습니다. 주요 변경 사항은 사용자 시음 기록에 대한 필터링 기능 추가, 페이지네이션 설정 업데이트, 그리고 객체의 첫 번째 사진 URL을 가져오는 유틸리티 함수 도입입니다.

주요 개선 사항 및 새로운 기능:

필터링 기능 추가:
- django_filters를 INSTALLED_APPS에 추가하고, pyproject.toml 파일에 django-filter 의존성을 추가했습니다.
- 사용자 시음 기록을 필터링할 수 있도록 TastedRecordFilter를 도입했습니다. 필터링 기준으로는 bean_type, origin_country, star_min, star_max, is_decaf가 포함됩니다.
- 필터링 및 정렬 기능을 포함한 사용자 시음 기록 리스트를 제공하는 UserTastedRecordListView를 추가했습니다.
- 사용자 시음 기록 API 엔드포인트를 repo/profiles/urls.py에 추가했습니다.

페이지네이션 및 설정:
- 기본 페이지네이션 크기를 5에서 12로 증가시켰습니다.

유틸리티 함수:
- 객체의 첫 번째 사진 URL을 가져오는 get_first_photo_url 유틸리티 함수를 추가했습니다.

시리얼라이저:
- 시음 기록 데이터를 직렬화하는 UserTastedRecordSerializer를 추가했습니다. 이 시리얼라이저는 bean_name, star, photo_url 필드를 포
함합니다.
- 새로 추가된 유틸리티 함수 get_first_photo_url을 UserTastedRecordSerializer에서 사용하도록 업데이트했습니다.

뷰 및 서비스:
- 새 필터링 기능을 위한 모듈과 서비스를 repo/profiles/views.py에 추가했습니다.
- 필터링된 사용자 시음 기록을 가져오는 get_user_tasted_records_by_filter 함수를 repo/records/services.py에 추가했습니다.
- 이 Pull Request는 사용자의 시음 기록을 더욱 세부적으로 관리하고, API 성능을 개선하는 중요한 변경 사항들을 포함하고 있습니다.