### PR TITLE
60 사용자가 찜한 원두 리스트 조회

### DIFF
--- a/repo/beans/serializers.py
+++ b/repo/beans/serializers.py
@@ -13,3 +13,12 @@ class BeanTasteReviewSerializer(serializers.ModelSerializer):
     class Meta:
         model = BeanTasteReview
         fields = "__all__"
+
+
+class UserBeanSerializer(serializers.ModelSerializer):
+    avg_star = serializers.DecimalField(max_digits=3, rounding="ROUND_HALF_UP", decimal_places=2, default=0)
+    tasted_records_cnt = serializers.IntegerField()
+
+    class Meta:
+        model = Bean
+        fields = ["id", "name", "origin_country", "roast_point", "avg_star", "tasted_records_cnt"]

--- a/repo/profiles/urls.py
+++ b/repo/profiles/urls.py
@@ -21,4 +21,5 @@ urlpatterns = [
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
     path("<int:id>/posts/", views.UserPostListAPIView.as_view(), name="user_posts"),
     path("<int:id>/tasted-records/", views.UserTastedRecordListView.as_view(), name="user_tasted_records"),
+    path("<int:id>/beans/", views.UserBeanListAPIView.as_view(), name="user_beans"),
 ]

--- a/repo/profiles/views.py
+++ b/repo/profiles/views.py
@@ -346,10 +346,9 @@ class SignupView(APIView):
         summary="자기 프로필 조회",
         description="""
             현재 로그인한 사용자의 프로필을 조회합니다.
-
             닉네임, 프로필 이미지, 커피 생활 방식, 팔로워 수, 팔로잉 수, 게시글 수를 반환합니다.
             담당자 : hwstar1204
-        """,
+         """,
         tags=["profile"],
     ),
     patch=extend_schema(
@@ -362,7 +361,6 @@ class SignupView(APIView):
         summary="자기 프로필 수정",
         description="""
             현재 로그인한 사용자의 프로필을 수정합니다.
-
             닉네임, 프로필 이미지, 소개, 프로필 링크, 커피 생활 방식, 선호하는 커피 맛, 자격증 여부를 수정합니다.
             담당자 : hwstar1204
         """,
@@ -443,13 +441,7 @@ class OtherProfileAPIView(APIView):
 
 @extend_schema_view(
     get=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="type",
-                type=str,
-                enum=["following", "follower"],
-            ),
-        ],
+        parameters=[OpenApiParameter(name="type", type=str, enum=["following", "follower"])],
         responses={
             200: UserFollowListSerializer,
             400: OpenApiResponse(description="Bad Request"),
@@ -459,7 +451,6 @@ class OtherProfileAPIView(APIView):
         description="""
             사용자의 팔로잉/팔로워 리스트를 조회합니다.
             type 파라미터로 팔로잉/팔로워 리스트를 구분합니다.
-
             담당자 : hwstar1204
         """,
         tags=["follow"],
@@ -488,13 +479,7 @@ class FollowListAPIView(APIView):
 
 @extend_schema_view(
     get=extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="type",
-                type=str,
-                enum=["following", "follower"],
-            ),
-        ],
+        parameters=[OpenApiParameter(name="type", type=str, enum=["following", "follower"])],
         responses={
             200: UserFollowListSerializer,
             400: OpenApiResponse(description="Bad Request"),
@@ -503,8 +488,7 @@ class FollowListAPIView(APIView):
         summary="사용자의 팔로잉/팔로워 리스트 조회",
         description="""
             특정 사용자의 팔로잉/팔로워 리스트를 조회합니다.
-            id 파라미터로 사용자의 id를 받고,type 파라미터로 팔로잉/팔로워 리스트를 구분합니다.
-
+            id 파라미터로 사용자의 id를 받고, type 파라미터로 팔로잉/팔로워 리스트를 구분합니다.
             담당자 : hwstar1204
         """,
         tags=["follow"],
@@ -515,7 +499,6 @@ class FollowListAPIView(APIView):
         description="""
             특정 사용자를 팔로우합니다.
             이미 팔로우 중인 경우 409 CONFLICT
-
             담당자 : hwstar1204
         """,
         tags=["follow"],
@@ -526,9 +509,8 @@ class FollowListAPIView(APIView):
         description="""
             특정 사용자의 언팔로우합니다.
             팔로우 중이 아닌 경우 404 NOT FOUND
-
-            담당자 : hwstar1204
-        """,
+             담당자 : hwstar1204
+         """,
         tags=["follow"],
     ),
 )
@@ -664,27 +646,10 @@ class UserPostListAPIView(APIView):
                 type=str,
                 enum=["케냐", "과테말라", "에티오피아", "브라질", "콜롬비아", "인도네시아", "온두라스", "탄자니아", "르완다"],
             ),
-            OpenApiParameter(
-                name="star_min",
-                type=float,
-                enum=[x / 2 for x in range(11)],
-            ),
-            OpenApiParameter(
-                name="star_max",
-                type=float,
-                enum=[x / 2 for x in range(11)],
-            ),
-            OpenApiParameter(
-                name="is_decaf",
-                type=bool,
-                enum=[True, False],
-            ),
-            OpenApiParameter(
-                name="ordering",
-                type=str,
-                enum=["-created_at", "-taste_review__star"],
-                required=False,
-            ),
+            OpenApiParameter(name="star_min", type=float, enum=[x / 2 for x in range(11)]),
+            OpenApiParameter(name="star_max", type=float, enum=[x / 2 for x in range(11)]),
+            OpenApiParameter(name="is_decaf", type=bool, enum=[True, False]),
+            OpenApiParameter(name="ordering", type=str, enum=["-created_at", "-taste_review__star"], required=False),
         ],
         responses=UserTastedRecordSerializer,
         summary="유저 시음기록 리스트 조회",
@@ -714,39 +679,14 @@ class UserTastedRecordListView(generics.ListAPIView):
             OpenApiParameter(
                 name="origin_country",
                 type=str,
-                enum=["케냐", "과테말라", "에티오피아", "브라질", "콜롬비아", "인도네시아", "온두라스", "탄자니아", "르완다"],
+                enum=["케냐", "과테말라", "에티오피아", "브라질", "콜비아", "인도네시아", "온두라스", "탄자니아", "르완다"],
             ),
-            OpenApiParameter(
-                name="is_decaf",
-                type=bool,
-                enum=[True, False],
-            ),
-            OpenApiParameter(
-                name="avg_star_min",
-                type=float,
-                enum=[x / 2 for x in range(11)],
-            ),
-            OpenApiParameter(
-                name="avg_star_max",
-                type=float,
-                enum=[x / 2 for x in range(11)],
-            ),
-            OpenApiParameter(
-                name="roast_point_min",
-                type=int,
-                enum=range(0, 6),
-            ),
-            OpenApiParameter(
-                name="roast_point_max",
-                type=int,
-                enum=range(0, 6),
-            ),
-            OpenApiParameter(
-                name="ordering",
-                type=str,
-                enum=["-note__created_at", "-avg_star", "-tasted_records_cnt"],
-                required=False,
-            ),
+            OpenApiParameter(name="is_decaf", type=bool, enum=[True, False]),
+            OpenApiParameter(name="avg_star_min", type=float, enum=[x / 2 for x in range(11)]),
+            OpenApiParameter(name="avg_star_max", type=float, enum=[x / 2 for x in range(11)]),
+            OpenApiParameter(name="roast_point_min", type=int, enum=range(0, 6)),
+            OpenApiParameter(name="roast_point_max", type=int, enum=range(0, 6)),
+            OpenApiParameter(name="ordering", type=str, enum=["-note__created_at", "-avg_star", "-tasted_records_cnt"], required=False),
         ],
         summary="유저 찜한 원두 리스트 조회",
         description="""

--- a/repo/records/filters.py
+++ b/repo/records/filters.py
@@ -5,15 +5,15 @@ from repo.records.models import TastedRecord
 
 
 class TastedRecordFilter(filters.FilterSet):
-    bean_type = filters.ChoiceFilter(field_name="bean__bean_type", choices=[("single", "single"), ("blend", "blend")])
+    bean_type = filters.ChoiceFilter(field_name="bean__bean_type", choices=[("single", "싱글 오리진"), ("blend", "블렌드")])
     origin_country = filters.CharFilter(field_name="bean__origin_country", lookup_expr="icontains")
+    is_decaf = filters.BooleanFilter(field_name="bean__is_decaf")
     star_min = filters.NumberFilter(field_name="taste_review__star", lookup_expr="gte")
     star_max = filters.NumberFilter(field_name="taste_review__star", lookup_expr="lte")
-    is_decaf = filters.BooleanFilter(field_name="bean__is_decaf")
 
     class Meta:
         model = TastedRecord
-        fields = ["bean_type", "origin_country", "star_min", "star_max", "is_decaf"]
+        fields = ["bean_type", "origin_country", "is_decaf", "star_min", "star_max"]
 
 
 class BeanFilter(filters.FilterSet):

--- a/repo/records/filters.py
+++ b/repo/records/filters.py
@@ -1,5 +1,6 @@
 from django_filters import rest_framework as filters
 
+from repo.beans.models import Bean
 from repo.records.models import TastedRecord
 
 
@@ -13,3 +14,17 @@ class TastedRecordFilter(filters.FilterSet):
     class Meta:
         model = TastedRecord
         fields = ["bean_type", "origin_country", "star_min", "star_max", "is_decaf"]
+
+
+class BeanFilter(filters.FilterSet):
+    bean_type = filters.ChoiceFilter(choices=[("single", "싱글 오리진"), ("blend", "블렌드")])
+    origin_country = filters.CharFilter(lookup_expr="icontains")
+    is_decaf = filters.BooleanFilter()
+    avg_star_min = filters.NumberFilter(field_name="avg_star", lookup_expr="gte")
+    avg_star_max = filters.NumberFilter(field_name="avg_star", lookup_expr="lte")
+    roast_point_min = filters.NumberFilter(field_name="roast_point", lookup_expr="gte")
+    roast_point_max = filters.NumberFilter(field_name="roast_point", lookup_expr="lte")
+
+    class Meta:
+        model = Bean
+        fields = ["bean_type", "origin_country", "is_decaf", "roast_point_min", "roast_point_max", "avg_star_min", "avg_star_max"]


### PR DESCRIPTION
## #️⃣연관된 이슈

> #50 #60 

## 📝작업 내용

이 Pull Request는 사용자 프로필 기능을 강화하고, 사용자 관련 데이터를 위한 새로운 시리얼라이저와 뷰를 추가하는 데 중점을 둔 여러 새로운 기능과 개선 사항을 도입합니다. 주요 변경 사항으로는 사용자 원두를 위한 새로운 시리얼라이저 추가, 사용자 원두를 조회하는 새로운 API 엔드포인트 추가, 그리고 이러한 새로운 기능을 지원하기 위한 필터와 서비스 업데이트가 포함됩니다.

새로운 기능:

- 사용자 원두 시리얼라이저 추가:
  - repo/beans/serializers.py에 avg_star와 tasted_records_cnt 필드를 포함한 UserBeanSerializer 추가.
- 새로운 API 엔드포인트:
  - 사용자 원두를 조회하는 엔드포인트를 repo/profiles/urls.py에 추가.
  - 새로운 엔드포인트를 지원하기 위해 UserBeanListAPIView를 repo/profiles/views.py에 추가.

개선 사항:

- 필터:
  - bean_type, origin_country, is_decaf 등 다양한 기준으로 원두를 필터링할 수 있도록 BeanFilter를 repo/records/filters.py에 추가.
 - 서비스:
   - 사용자가 저장한 원두와 그 원두의 평균 별점 및 테이스팅 기록 수를 함께 가져오는 get_user_saved_beans 함수를 
   - repo/records/services.py에 추가.

코드 정리:
- 파라미터 단순화:
  - repo/profiles/views.py의 여러 메서드에서 OpenApiParameter 정의를 한 줄로 통합하여 간소화.

이 변경 사항들은 사용자 프로필과 원두 상호작용 기능을 개선하여 사용자 경험을 향상시킵니다.