### PR TITLE
61 사용자 저장한 노트 리스트 조회

### DIFF
--- a/repo/profiles/urls.py
+++ b/repo/profiles/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path("<int:id>/posts/", views.UserPostListAPIView.as_view(), name="user_posts"),
     path("<int:id>/tasted-records/", views.UserTastedRecordListView.as_view(), name="user_tasted_records"),
     path("<int:id>/beans/", views.UserBeanListAPIView.as_view(), name="user_beans"),
+    path("<int:id>/notes/", views.UserNoteAPIView.as_view(), name="user_notes"),
 ]

--- a/repo/profiles/views.py
+++ b/repo/profiles/views.py
@@ -39,6 +39,7 @@ from repo.profiles.services import get_follower_list, get_following_list
 from repo.records.filters import BeanFilter, TastedRecordFilter
 from repo.records.models import Post
 from repo.records.posts.serializers import UserPostSerializer
+from repo.records.serializers import UserNoteSerializer
 from repo.records.services import (
     get_user_posts_by_subject,
     get_user_saved_beans,
@@ -710,3 +711,21 @@ class UserBeanListAPIView(generics.ListAPIView):
         queryset = get_user_saved_beans(user)
         ordering = self.request.query_params.get("ordering", "-note__created_at")
         return queryset.order_by(ordering)
+
+
+class UserNoteAPIView(APIView):
+    @extend_schema(
+        summary="유저 저장한 노트 조회",
+        description="특정 사용자의 저장한 노트를 조회합니다.",
+        responses={200: UserNoteSerializer(many=True), 404: OpenApiResponse(description="Not Found")},
+        tags=["profile_records"],
+    )
+    def get(self, request, id):
+        user = get_object_or_404(CustomUser, id=id)
+        notes = user.note_set.filter(bean__isnull=True).select_related("post", "tasted_record")
+
+        paginator = PageNumberPagination()
+        paginated_notes = paginator.paginate_queryset(notes, request)
+
+        serializer = UserNoteSerializer(paginated_notes, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/repo/records/managers.py
+++ b/repo/records/managers.py
@@ -32,7 +32,7 @@ class PostManagers(models.Manager):
 
 
 class NoteManagers(models.Manager):
-    model_map = {"post": "repo.records.Post", "tasted_record": "repo.records.Tasted_Record", "bean": "repo.beans.Bean"}
+    model_map = {"post": "repo.records.Post", "tasted_record": "repo.records.TastedRecord", "bean": "repo.beans.Bean"}
 
     def create_note_for_object(self, user, object_type, object_id):
         from repo.records.models import Note

--- a/repo/records/serializers.py
+++ b/repo/records/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from repo.common.utils import get_first_photo_url
 from repo.profiles.serializers import UserSimpleSerializer
 from repo.records.models import Comment, Note, Post, TastedRecord
 from repo.records.posts.serializers import PostListSerializer
@@ -13,6 +14,46 @@ class FeedSerializer(serializers.ModelSerializer):
         elif isinstance(instance, TastedRecord):
             return TastedRecordListSerializer(instance).data
         return super().to_representation(instance)
+
+
+class UserNoteSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        if isinstance(instance, Note):
+            if instance.post:
+                return NotePostSimpleSerializer(instance).data
+            elif instance.tasted_record:
+                return NoteTastedRecordSimpleSerializer(instance).data
+        return super().to_representation(instance)
+
+
+class NotePostSimpleSerializer(serializers.ModelSerializer):
+    post_id = serializers.IntegerField(source="post.id")
+    title = serializers.CharField(source="post.title")
+    subject = serializers.CharField(source="post.subject")
+    created_at = serializers.DateTimeField(source="post.created_at")
+    nickname = serializers.CharField(source="post.author.nickname", read_only=True)
+    photo_url = serializers.SerializerMethodField()
+
+    def get_photo_url(self, obj):
+        return get_first_photo_url(obj.post)
+
+    class Meta:
+        model = Note
+        fields = ["post_id", "title", "subject", "created_at", "nickname", "photo_url"]
+
+
+class NoteTastedRecordSimpleSerializer(serializers.ModelSerializer):
+    tasted_record_id = serializers.IntegerField(source="tasted_record.id")
+    bean_name = serializers.CharField(source="tasted_record.bean.name")
+    flavor = serializers.CharField(source="tasted_record.taste_review.flavor")
+    photo_url = serializers.SerializerMethodField()
+
+    def get_photo_url(self, obj):
+        return get_first_photo_url(obj.tasted_record)
+
+    class Meta:
+        model = Note
+        fields = ["tasted_record_id", "bean_name", "flavor", "photo_url"]
 
 
 class CommentSerializer(serializers.ModelSerializer):

--- a/repo/records/serializers.py
+++ b/repo/records/serializers.py
@@ -1,6 +1,5 @@
 from rest_framework import serializers
 
-from repo.common.utils import get_first_photo_url
 from repo.profiles.serializers import UserSimpleSerializer
 from repo.records.models import Comment, Note, Post, TastedRecord
 from repo.records.posts.serializers import PostListSerializer
@@ -32,10 +31,7 @@ class NotePostSimpleSerializer(serializers.ModelSerializer):
     subject = serializers.CharField(source="post.subject")
     created_at = serializers.DateTimeField(source="post.created_at")
     nickname = serializers.CharField(source="post.author.nickname", read_only=True)
-    photo_url = serializers.SerializerMethodField()
-
-    def get_photo_url(self, obj):
-        return get_first_photo_url(obj.post)
+    photo_url = serializers.CharField(read_only=True)
 
     class Meta:
         model = Note
@@ -46,10 +42,7 @@ class NoteTastedRecordSimpleSerializer(serializers.ModelSerializer):
     tasted_record_id = serializers.IntegerField(source="tasted_record.id")
     bean_name = serializers.CharField(source="tasted_record.bean.name")
     flavor = serializers.CharField(source="tasted_record.taste_review.flavor")
-    photo_url = serializers.SerializerMethodField()
-
-    def get_photo_url(self, obj):
-        return get_first_photo_url(obj.tasted_record)
+    photo_url = serializers.CharField(read_only=True)
 
     class Meta:
         model = Note


### PR DESCRIPTION
## #️⃣연관된 이슈

> #50 #61 

## 📝작업 내용
이번 Pull Request는 유저의 노트를 조회하는 새로운 API 엔드포인트를 추가하며, 관련된 여러 파일에 걸친 변경 사항들을 포함하고 있습니다. 주요 변경 사항은 새로운 엔드포인트 추가, 필요한 유틸리티 및 시리얼라이저의 임포트, 유저 노트 전용 시리얼라이저 생성입니다.

새로운 API 엔드포인트:

- 유저 노트 조회 요청을 처리하기 위해 UserNoteAPIView URL 패턴을 추가했습니다.
- UserNoteAPIView 클래스를 추가하여 유저 노트를 조회하고 페이지네이션 처리하며, 노트에 사진을 추가하는 로직을 구현했습니다.

시리얼라이저:

- 유저 노트, 게시글, 시음 기록을 직렬화하기 위한 UserNoteSerializer, NotePostSimpleSerializer, NoteTastedRecordSimpleSerializer를 추가했습니다.

사소한 수정:
- NoteManagers 클래스에서 tasted_record의 모델명을 수정했습니다.