### PR TITLE
38 홈 전체 게시글 시음기록 feed 리스트 조회 추가 수정

### DIFF
--- a/repo/profiles/views.py
+++ b/repo/profiles/views.py
@@ -412,7 +412,6 @@ class FollowListAPIView(APIView):
             return Response({"detail": "Invalid type parameter"}, status=status.HTTP_400_BAD_REQUEST)
 
         paginator = PageNumberPagination()
-        paginator.page_size = 12
         page_obj = paginator.paginate_queryset(data, request)
 
         serializer = UserFollowListSerializer(page_obj, many=True)
@@ -433,7 +432,6 @@ class FollowListCreateDeleteAPIView(APIView):
             return Response({"detail": "Invalid type parameter"}, status=status.HTTP_400_BAD_REQUEST)
 
         paginator = PageNumberPagination()
-        paginator.page_size = 12
         page_obj = paginator.paginate_queryset(data, request)
 
         serializer = UserFollowListSerializer(page_obj, many=True)
@@ -518,7 +516,6 @@ class UserPostListAPIView(APIView):
         posts = get_user_posts_by_subject(user, subject_choice)
 
         paginator = PageNumberPagination()
-        paginator.page_size = 12
         paginated_posts = paginator.paginate_queryset(posts, request)
 
         serializer = UserPostSerializer(paginated_posts, many=True)

--- a/repo/records/managers.py
+++ b/repo/records/managers.py
@@ -17,11 +17,10 @@ class PostManagers(models.Manager):
     def get_subject_weekly_posts(self, subject):
         from .models import Post
 
-        if subject == "all":
-            # 전체 주제의 게시글 중 일주일 안에 작성된 게시글
-            posts = Post.objects.filter(created_at__gte=timezone.now() - timedelta(days=7))
-        else:
-            posts = Post.objects.filter(subject=subject, created_at__gte=timezone.now() - timedelta(days=7))
+        time_threshold = timezone.now() - timedelta(days=7)
+        posts = Post.objects.filter(created_at__gte=time_threshold)
+        if subject is not None:
+            posts = posts.filter(subject=subject)
 
         return posts
 

--- a/repo/records/models.py
+++ b/repo/records/models.py
@@ -31,17 +31,13 @@ class TastedRecord(models.Model):
 
 
 class Post(models.Model):
-
+    # fmt: off
     SUBJECT_TYPE_CHOICES = (
-        ("전체", "all"),
-        ("일반", "normal"),
-        ("카페", "cafe"),
-        ("원두", "bean"),
-        ("정보", "info"),
-        ("장비", "gear"),
-        ("질문", "question"),
-        ("고민", "worry"),
+        ("일반", "normal"), ("카페", "cafe"),
+        ("원두", "bean"), ("정보", "info"),
+        ("질문", "question"), ("고민", "worry"),
     )
+    # fmt: on
 
     author = models.ForeignKey(CustomUser, on_delete=models.CASCADE, verbose_name="작성자")
     tasted_records = models.ManyToManyField(TastedRecord, blank=True, related_name="posts", verbose_name="관련 시음 기록")

--- a/repo/records/posts/serializers.py
+++ b/repo/records/posts/serializers.py
@@ -13,18 +13,18 @@ class PostListSerializer(serializers.ModelSerializer):
     author = UserSimpleSerializer(read_only=True)
     photos = PhotoSerializer(many=True, source="photo_set", read_only=True)
     tasted_records = TastedRecordInPostSerializer("tasted_records", many=True, read_only=True)
-    like_cnt = serializers.IntegerField(source="like_cnt.count")
-    is_user_liked = serializers.SerializerMethodField()
+    created_at = serializers.SerializerMethodField()
+    likes = serializers.IntegerField()
+    comments = serializers.IntegerField()
+    is_user_liked = serializers.BooleanField()
+    is_user_noted = serializers.BooleanField()
 
-    def get_is_user_liked(self, obj):
-        request = self.context.get("request")
-        if request and request.user.is_authenticated:
-            return obj.like_cnt.filter(id=request.user.id).exists()
-        return False
+    def get_created_at(self, obj):
+        return get_time_difference(obj.created_at)
 
     class Meta:
         model = Post
-        fields = "__all__"
+        exclude = ["like_cnt"]
 
 
 class TopPostSerializer(PostListSerializer):

--- a/repo/records/posts/views.py
+++ b/repo/records/posts/views.py
@@ -87,7 +87,7 @@ class PostListCreateAPIView(APIView):
         subject_mapping = dict(Post.SUBJECT_TYPE_CHOICES)
         subject_value = subject_mapping.get(subject, None)
 
-        posts = get_post_feed(request.user, subject_value)
+        posts = get_post_feed(request, request.user, subject_value)
 
         paginator = PageNumberPagination()
         paginated_posts = paginator.paginate_queryset(posts, request)

--- a/repo/records/posts/views.py
+++ b/repo/records/posts/views.py
@@ -50,10 +50,19 @@ from repo.records.services import get_post_detail, get_post_feed
                 ],
             ),
         ],
-        responses=PostListSerializer,
-        summary="홈 게시글 리스트 조회",
+        responses={200: PostListSerializer},
+        summary="홈 [게시글] 피드 조회",
         description="""
-            홈 피드의 게시글 list 데이터를 가져옵니다.
+            홈 피드의 주제별 게시글 list 데이터를 가져옵니다.
+            - 순서: 팔로잉, 일반
+            - 정렬: 최신순
+            - 페이지네이션 적용 (12개)
+            - 30분이내 조회하지않은 게시글만 가져옵니다.
+
+            Notice:
+            - like_cnt에서 likes로 변경
+            - comments(댓글 수), is_user_noted(사용자 저장여부) 추가 됨
+
             담당자: hwstar1204
         """,
         tags=["posts"],
@@ -258,7 +267,6 @@ class TopSubjectPostsAPIView(APIView):
         ],
     )
     def get(self, request):
-        subject = request.GET.get("subject")
         subject = request.query_params.get("subject")
 
         subject_mapping = dict(Post.SUBJECT_TYPE_CHOICES)

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -49,6 +49,10 @@ class FeedSchema:
             TastedRecordListSerializer or PostListSerializer
             (아래 Schemas 참조)
 
+            Notice:
+            - like_cnt에서 likes로 변경
+            - comments(댓글 수), is_user_noted(사용자 저장여부) 추가 됨
+
             담당자 : hwstar1204
         """,
         tags=[Feed_Tag],

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -8,7 +8,7 @@ from drf_spectacular.utils import (
 
 from repo.common.serializers import PageNumberSerializer
 from repo.records.posts.serializers import PostListSerializer
-from repo.records.serializers import CommentSerializer, LikeSerializer, NoteSerializer
+from repo.records.serializers import CommentSerializer, NoteSerializer
 from repo.records.tasted_record.serializers import TastedRecordListSerializer
 
 Feed_Tag = "Feed"
@@ -63,27 +63,69 @@ class FeedSchema:
 
 class LikeSchema:
     like_post_schema = extend_schema(
-        request=LikeSerializer,
+        parameters=[
+            OpenApiParameter(
+                name="object_type",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="object type",
+                enum=["post", "tasted_record", "comment"],
+            ),
+            OpenApiParameter(
+                name="object_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                description="object id",
+            ),
+        ],
         responses={
             201: OpenApiResponse(description="like success"),
-            200: OpenApiResponse(description="like cancel"),
-            400: OpenApiResponse(description="Bad Request"),
+            401: OpenApiResponse(description="Unauthorized"),
             404: OpenApiResponse(description="Not Found"),
+            409: OpenApiResponse(description="Already liked"),
         },
-        summary="좋아요 추가/취소 API",
+        summary="좋아요 추가",
         description="""
             object_type : "post" or "tasted_record" or "comment"
             object_id : 좋아요를 처리할 객체의 ID
-
-            response:
-                201: 좋아요 추가, 200: 좋아요 취소
 
             담당자 : hwstar1204
         """,
         tags=[Like_Tage],
     )
 
-    like_schema_view = extend_schema_view(post=like_post_schema)
+    like_delete_schema = extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="object_type",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="object type",
+                enum=["post", "tasted_record", "comment"],
+            ),
+            OpenApiParameter(
+                name="object_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                description="object id",
+            ),
+        ],
+        responses={
+            204: OpenApiResponse(description="like deleted"),
+            401: OpenApiResponse(description="Unauthorized"),
+            404: OpenApiResponse(description="Not Found"),
+        },
+        summary="좋아요 삭제",
+        description="""
+                object_type : "post" or "tasted_record" or "comment"
+                object_id : 좋아요를 처리할 객체의 ID
+
+                담당자 : hwstar1204
+            """,
+        tags=[Like_Tage],
+    )
+
+    like_schema_view = extend_schema_view(post=like_post_schema, delete=like_delete_schema)
 
 
 class NoteSchema:

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -8,7 +8,7 @@ from drf_spectacular.utils import (
 
 from repo.common.serializers import PageNumberSerializer
 from repo.records.posts.serializers import PostListSerializer
-from repo.records.serializers import CommentSerializer, NoteSerializer
+from repo.records.serializers import CommentSerializer
 from repo.records.tasted_record.serializers import TastedRecordListSerializer
 
 Feed_Tag = "Feed"
@@ -130,7 +130,6 @@ class LikeSchema:
 
 class NoteSchema:
     note_post_schema = extend_schema(
-        request=NoteSerializer,
         responses={
             200: OpenApiResponse(description="Note already exists"),
             201: OpenApiResponse(description="Note created"),
@@ -145,26 +144,22 @@ class NoteSchema:
         tags=[Note_Tag],
     )
 
-    note_schema_view = extend_schema_view(post=note_post_schema)
-
-
-class NoteDetailSchema:
-    note_detail_delete_schema = extend_schema(
+    note_delete_schema = extend_schema(
         responses={
             200: OpenApiResponse(description="Note deleted"),
             404: OpenApiResponse(description="Note not found"),
         },
         summary="노트 삭제",
         description="""
-                object_type : "post" 또는 "tasted_record"
-                object_id : 노트를 처리할 객체의 ID
+            object_type : "post" 또는 "tasted_record"
+            object_id : 노트를 처리할 객체의 ID
 
-                담당자: hwstar1204
-            """,
+            담당자: hwstar1204
+        """,
         tags=[Note_Tag],
     )
 
-    note_detail_schema_view = extend_schema_view(delete=note_detail_delete_schema)
+    note_schema_view = extend_schema_view(post=note_post_schema, delete=note_delete_schema)
 
 
 class CommentSchema:

--- a/repo/records/serializers.py
+++ b/repo/records/serializers.py
@@ -76,11 +76,6 @@ class CommentSerializer(serializers.ModelSerializer):
         fields = ["id", "content", "parent", "author", "like_cnt", "created_at", "replies", "is_user_liked"]
 
 
-class LikeSerializer(serializers.Serializer):
-    object_type = serializers.ChoiceField(choices=["post", "tasted_record", "comment"])
-    object_id = serializers.IntegerField()
-
-
 class NoteSerializer(serializers.ModelSerializer):
     object_type = serializers.ChoiceField(choices=["post", "tasted_record"])
     object_id = serializers.IntegerField()

--- a/repo/records/serializers.py
+++ b/repo/records/serializers.py
@@ -74,12 +74,3 @@ class CommentSerializer(serializers.ModelSerializer):
     class Meta:
         model = Comment
         fields = ["id", "content", "parent", "author", "like_cnt", "created_at", "replies", "is_user_liked"]
-
-
-class NoteSerializer(serializers.ModelSerializer):
-    object_type = serializers.ChoiceField(choices=["post", "tasted_record"])
-    object_id = serializers.IntegerField()
-
-    class Meta:
-        model = Note
-        fields = ["object_type", "object_id"]

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -23,6 +23,11 @@ from repo.records.posts.serializers import PostListSerializer
 from repo.records.tasted_record.serializers import TastedRecordListSerializer
 
 
+def get_following_users(user):
+    """사용자가 팔로우한 유저 리스트를 가져오는 함수"""
+    return Relationship.objects.following(user.id).values_list("to_user", flat=True)
+
+
 def get_serialized_data(request, page_obj):
     """
     페이지 객체를 받아 시리얼라이즈된 데이터를 반환하는 함수
@@ -41,7 +46,7 @@ def get_following_feed(request, user):
     사용자가 팔로잉한 유저들의 1시간 이내 작성한 시음기록과 게시글을 랜덤순으로 가져오는 함수
     30분이내 조회한 기록, 프라이빗한 시음기록은 제외
     """
-    following_users = Relationship.objects.following(user.id).values_list("to_user", flat=True)
+    following_users = get_following_users(user)
     one_hour_ago = timezone.now() - timedelta(hours=1)
 
     following_tasted_record = (
@@ -79,7 +84,7 @@ def get_common_feed(request, user):
     30분이내 조회한 기록, 프라이빗한 시음기록은 제외
     팔로잉한 유저 기록 제외
     """
-    following_users = Relationship.objects.following(user.id).values_list("to_user", flat=True)
+    following_users = get_following_users(user)
 
     common_tasted_record = (
         TastedRecord.objects.filter(is_private=False)
@@ -152,7 +157,7 @@ def get_tasted_record_queryset(authors, user):
 
 
 def get_tasted_record_feed(user):
-    following_users = Relationship.objects.following(user.id).values_list("to_user", flat=True)
+    following_users = get_following_users(user)
 
     # 팔로우한 유저의 tasted records
     followed_records = get_tasted_record_queryset(following_users, user)
@@ -202,7 +207,7 @@ def get_post_queryset(authors, user, subject):
 
 def get_post_feed(user, subject):
     """사용자가 팔로우한 유저와 추가 게시글을 가져오는 함수"""
-    following_users = Relationship.objects.following(user.id).values_list("to_user", flat=True)
+    following_users = get_following_users(user)
 
     following_posts = get_post_queryset(following_users, user, subject)
 

--- a/repo/records/tasted_record/serializers.py
+++ b/repo/records/tasted_record/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from repo.beans.serializers import BeanSerializer, BeanTasteReviewSerializer
 from repo.common.serializers import PhotoSerializer
-from repo.common.utils import get_first_photo_url
+from repo.common.utils import get_first_photo_url, get_time_difference
 from repo.profiles.serializers import UserSimpleSerializer
 from repo.records.models import Photo, TastedRecord
 
@@ -14,10 +14,14 @@ class TastedRecordListSerializer(serializers.ModelSerializer):
     star_rating = serializers.IntegerField(source="taste_review.star")
     flavor = serializers.CharField(source="taste_review.flavor")
     photos = PhotoSerializer(many=True, source="photo_set", read_only=True)
+    created_at = serializers.SerializerMethodField()
     likes = serializers.IntegerField()
     comments = serializers.IntegerField()
     is_user_liked = serializers.BooleanField()
     is_user_noted = serializers.BooleanField()
+
+    def get_created_at(self, obj):
+        return get_time_difference(obj.created_at)
 
     # fmt: off
     class Meta:

--- a/repo/records/tasted_record/serializers.py
+++ b/repo/records/tasted_record/serializers.py
@@ -14,33 +14,20 @@ class TastedRecordListSerializer(serializers.ModelSerializer):
     star_rating = serializers.IntegerField(source="taste_review.star")
     flavor = serializers.CharField(source="taste_review.flavor")
     photos = PhotoSerializer(many=True, source="photo_set", read_only=True)
-    like_cnt = serializers.IntegerField(source="like_cnt.count")
-    is_user_liked = serializers.SerializerMethodField()
+    likes = serializers.IntegerField()
+    comments = serializers.IntegerField()
+    is_user_liked = serializers.BooleanField()
+    is_user_noted = serializers.BooleanField()
 
-    def get_is_user_liked(self, obj):
-        user = self.context["request"].user
-        if user.is_authenticated:
-            return obj.like_cnt.filter(id=user.id).exists()
-        return False
-
+    # fmt: off
     class Meta:
         model = TastedRecord
         fields = [
-            "id",
-            "author",
-            "bean_name",
-            "bean_type",
-            "star_rating",
-            "flavor",
-            "content",
-            "view_cnt",
-            "like_cnt",
-            "is_private",
-            "created_at",
-            "tag",
-            "photos",
-            "is_user_liked",
+            "id", "author", "bean_name", "bean_type", "star_rating", "flavor",
+            "content", "view_cnt", "is_private", "created_at", "tag", "photos",
+            "likes", "comments", "is_user_liked", "is_user_noted"
         ]
+    # fmt: on
 
 
 class TastedRecordDetailSerializer(serializers.ModelSerializer):

--- a/repo/records/tasted_record/views.py
+++ b/repo/records/tasted_record/views.py
@@ -72,7 +72,7 @@ class TastedRecordListCreateAPIView(APIView):
     """
 
     def get(self, request, *args, **kwargs):
-        tasted_records = get_tasted_record_feed(request.user)
+        tasted_records = get_tasted_record_feed(request, request.user)
 
         paginator = PageNumberPagination()
         paginated_tasted_records = paginator.paginate_queryset(tasted_records, request)

--- a/repo/records/tasted_record/views.py
+++ b/repo/records/tasted_record/views.py
@@ -66,7 +66,6 @@ class TastedRecordListCreateAPIView(APIView):
         tasted_records = get_tasted_record_feed(request.user)
 
         paginator = PageNumberPagination()
-        paginator.page_size = 12
         paginated_tasted_records = paginator.paginate_queryset(tasted_records, request)
 
         serializer = TastedRecordListSerializer(paginated_tasted_records, many=True, context={"request": request})

--- a/repo/records/tasted_record/views.py
+++ b/repo/records/tasted_record/views.py
@@ -24,11 +24,20 @@ from repo.records.tasted_record.service import update_tasted_record
     get=extend_schema(
         parameters=[PageNumberSerializer],
         responses={200: TastedRecordListSerializer},
-        summary="홈 시음기록 리스트 조회",
+        summary="홈 [시음기록] 피드 조회",
         description="""
             홈 피드의 시음기록 list를 최신순으로 가져옵니다.
-            순서: 팔로잉, 최신순
-            담당자 : hwstar1204
+            - 순서: 팔로잉, 일반
+            - 정렬: 최신순
+            - 페이지네이션 적용 (12개)
+            - 30분이내 조회하지않은 게시글 가져옵니다.
+            - 프라이빗한 시음기록은 제외
+
+            Notice:
+            - like_cnt에서 likes로 변경
+            - comments(댓글 수), is_user_noted(사용자 저장여부) 추가 됨
+
+            담당자: hwstar1204
         """,
         tags=["tasted_records"],
     ),

--- a/repo/records/urls.py
+++ b/repo/records/urls.py
@@ -9,7 +9,6 @@ urlpatterns = [
     path("like/<str:object_type>/<int:object_id>/", views.LikeApiView.as_view(), name="records-likes"),
     path("comment/<int:id>", views.CommentDetailAPIView.as_view(), name="comment-detail"),
     path("comment/<str:object_type>/<int:object_id>", views.CommentApiView.as_view(), name="comment-list"),
-    path("note/", views.NoteApiView.as_view(), name="note-list"),
-    path("note/<str:object_type>/<int:object_id>/", views.NoteDetailApiView.as_view(), name="note-detail"),
+    path("note/<str:object_type>/<int:object_id>/", views.NoteApiView.as_view(), name="note"),
     path("image/", views.ImageApiView.as_view(), name="image-upload"),  # 이미지 업로드 테스트용
 ]

--- a/repo/records/urls.py
+++ b/repo/records/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     path("post/", include("repo.records.posts.urls")),
     path("tasted_record/", include("repo.records.tasted_record.urls")),
     path("feed/", views.FeedAPIView.as_view(), name="feed"),
-    path("like", views.LikeApiView.as_view(), name="records-likes"),
+    path("like/<str:object_type>/<int:object_id>/", views.LikeApiView.as_view(), name="records-likes"),
     path("comment/<int:id>", views.CommentDetailAPIView.as_view(), name="comment-detail"),
     path("comment/<str:object_type>/<int:object_id>", views.CommentApiView.as_view(), name="comment-list"),
     path("note/", views.NoteApiView.as_view(), name="note-list"),

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -10,7 +10,7 @@ from repo.common.serializers import PhotoSerializer
 from repo.common.utils import delete, update
 from repo.records.models import Comment, Note, Photo, Post, TastedRecord
 from repo.records.schemas import *
-from repo.records.serializers import CommentSerializer, NoteSerializer
+from repo.records.serializers import CommentSerializer
 from repo.records.services import (
     get_comment,
     get_comment_list,
@@ -100,14 +100,8 @@ class LikeApiView(APIView):
 # TODO NoteAPI, NoteDetailAPI 통합 가능
 @NoteSchema.note_schema_view
 class NoteApiView(APIView):
-    def post(self, request):
-        serializer = NoteSerializer(data=request.data)
-        if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
+    def post(self, request, object_type, object_id):
         user = request.user
-        object_type = serializer.validated_data["object_type"]
-        object_id = serializer.validated_data["object_id"]
 
         existing_note = Note.objects.existing_note(user, object_type, object_id)
         if existing_note:
@@ -116,9 +110,6 @@ class NoteApiView(APIView):
         Note.objects.create_note_for_object(user, object_type, object_id)
         return Response({"detail": "note created"}, status=status.HTTP_201_CREATED)
 
-
-@NoteDetailSchema.note_detail_schema_view
-class NoteDetailApiView(APIView):
     def delete(self, request, object_type, object_id):
         user = request.user
 

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -41,7 +41,7 @@ class FeedAPIView(APIView):
         elif feed_type == "common":
             data = get_common_feed(request, user)
         else:  # refresh
-            data = get_refresh_feed()
+            data = get_refresh_feed(user)
 
         paginator = Paginator(data, 12)
         page_obj = paginator.get_page(page)

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -138,7 +138,6 @@ class CommentApiView(APIView):
         comments = get_comment_list(object_type, object_id)
 
         paginator = PageNumberPagination()
-        paginator.page_size = 12
         page_obj = paginator.paginate_queryset(comments, request)
 
         serializer = CommentSerializer(page_obj, many=True)

--- a/tests/note_tests.py
+++ b/tests/note_tests.py
@@ -3,7 +3,6 @@ from django.urls import reverse
 from rest_framework import status
 
 from repo.records.models import Note
-from repo.records.serializers import NoteSerializer
 
 
 @pytest.mark.django_db
@@ -33,7 +32,6 @@ def test_get_note_detail(api_client, post_note):
     url = reverse("note-detail", kwargs={"id": post_note.id})
     response = api_client.get(url)
     assert response.status_code == status.HTTP_200_OK
-    assert response.data == NoteSerializer(post_note).data
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38

## 📝작업 내용

요약 
- 해당 게시물의 댓글 수, 사용자의 저장여부 데이터 추가
- 좋아요 토글 방식 분리
- 저장한 노트 생성 API 엔드포인트 수정

---

1. 페이지네이션 개선
- repo/profiles/views.py에서 하드코딩된 페이지네이션 크기를 제거하고, 설정을 통해 조정 가능하도록 수정했습니다.

2. 필터링 로직 개선
- repo/records/managers.py에서 게시물 주제별 필터링 조건을 통합하여 코드 단순화 및 유지보수성을 개선했습니다.

3. 리얼라이저 및 스키마 업데이트
- PostListSerializer에 새로운 필드(likes, comments, is_user_liked, is_user_noted)를 추가하고 like_cnt 필드를 제거했습니다.
- OpenApiParameter와 OpenApiExample 정의를 개선하여 주제 필터링 옵션을 추가하고 API 문서를 강화했습니다.
- 좋아요/노트 기능을 추가 및 삭제 엔드포인트로 분리하고, 스키마 정의를 최신화했습니다.

4. 코드 리팩토링
- repo/records/services.py에서 공통 쿼리 로직을 헬퍼 함수로 추출해 코드 가독성을 높였습니다.

5. 미사용 코드 제거
- LikeSerializer와 NoteSerializer 등 사용되지 않는 시리얼라이저를 삭제했습니다.


close #38 