### PR TITLE
38 홈 전체 게시글 시음기록 (비회원)

### DIFF
--- a/repo/common/utils.py
+++ b/repo/common/utils.py
@@ -1,9 +1,10 @@
 from datetime import timedelta
-from typing import Optional, Tuple, Type
+from typing import Callable, Optional, Tuple, Type
 
-from django.db.models import Model
+from django.db.models import Model, QuerySet
 from django.utils import timezone
 from rest_framework import status
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.serializers import Serializer
@@ -93,6 +94,42 @@ def delete(request: Request, pk: int, model: Type[Model]) -> Response:
 
     data.delete()
     return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+def get_paginated_response_with_func(request: Request, queryset: QuerySet, serializer_func: Callable) -> Response:
+    """
+    페이지네이션된 응답을 생성하는 매서드 (직렬화 객체 사용)
+
+    Args:
+        request (Request): 클라이언트로부터의 요청 객체
+        queryset (QuerySet): 페이지네이션할 쿼리셋
+        serializer_func (Serializer): 데이터를 직렬화할 직렬화 객체 생성 매서드
+
+    Returns:
+        Response: 페이지네이션된 응답
+    """
+    paginator = PageNumberPagination()
+    data = paginator.paginate_queryset(queryset, request)
+    serialized_data = serializer_func(request, data)
+    return paginator.get_paginated_response(serialized_data)
+
+
+def get_paginated_response_with_class(request: Request, queryset: QuerySet, serializer_class: Type[Serializer]) -> Response:
+    """
+    페이지네이션된 응답을 생성하는 매서드 (직렬화 클래스 사용)
+
+    Args:
+        request (Request): 클라이언트로부터의 요청 객체
+        queryset (QuerySet): 페이지네이션할 쿼리셋
+        serializer_class (Type[Serializer]): 데이터를 직렬화할 직렬화 클래스
+
+    Returns:
+        Response: 페이지네이션된 응답
+    """
+    paginator = PageNumberPagination()
+    data = paginator.paginate_queryset(queryset, request)
+    serialized_data = serializer_class(data, many=True, context={"request": request}).data
+    return paginator.get_paginated_response(serialized_data)
 
 
 def get_time_difference(object_created_at: timezone) -> str:

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -52,6 +52,7 @@ class FeedSchema:
             Notice:
             - like_cnt에서 likes로 변경
             - comments(댓글 수), is_user_noted(사용자 저장여부) 추가 됨
+            - 비회원일경우 랜덤으로 시음기록을 가져옵니다. (feed_type 쿼리 파라미터 미사용)
 
             담당자 : hwstar1204
         """,

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -23,16 +23,27 @@ from repo.records.posts.serializers import PostListSerializer
 from repo.records.tasted_record.serializers import TastedRecordListSerializer
 
 
-def get_serialized_data(request, page_obj):
+def serialize_tasted_record_list(item, request):
+    """TastedRecord 객체를 시리얼라이즈하는 함수"""
+    return TastedRecordListSerializer(item, context={"request": request}).data
+
+
+def serialize_post_list(item, request):
+    """Post 객체를 시리얼라이즈하는 함수"""
+    return PostListSerializer(item, context={"request": request}).data
+
+
+def get_serialized_data(request, page_obj_list):
     """
     페이지 객체를 받아 시리얼라이즈된 데이터를 반환하는 함수
     게시글 리스트 or 시음기록 리스트
     """
     obj_list = []
-    for item in page_obj.object_list:
-        serializer = TastedRecordListSerializer if isinstance(item, TastedRecord) else PostListSerializer
-        obj_list.append(serializer(item, context={"request": request}).data)
-
+    for item in page_obj_list:
+        if isinstance(item, TastedRecord):
+            obj_list.append(serialize_tasted_record_list(item, request))
+        else:
+            obj_list.append(serialize_post_list(item, request))
     return obj_list
 
 

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -4,12 +4,14 @@ from itertools import chain
 
 from django.db.models import (
     Avg,
+    BooleanField,
     Count,
     Exists,
     FloatField,
     OuterRef,
     Prefetch,
     Q,
+    Value,
 )
 from django.db.models.functions import Coalesce
 from django.shortcuts import get_object_or_404
@@ -94,7 +96,6 @@ def get_post_feed_queryset(user, add_filter=None, exclude_filter=None, subject=N
             is_user_liked=Exists(is_user_liked_post_subquery),
             is_user_noted=Exists(is_user_noted_post_subquery),
         )
-        .order_by("-id")
     )
 
 
@@ -117,7 +118,6 @@ def get_tasted_record_feed_queryset(user, add_filter=None, exclude_filter=None):
             is_user_liked=Exists(is_user_liked_tasted_record_subquery),
             is_user_noted=Exists(is_user_noted_tasted_record_subquery),
         )
-        .order_by("-id")
     )
 
 
@@ -132,13 +132,15 @@ def get_following_feed(request, user):
     # 1. 팔로우한 유저의 시음기록, 게시글
     tr_add_filter = {"author__in": following_users, "is_private": False, "created_at__gte": one_hour_ago}
     following_tasted_records = get_tasted_record_feed_queryset(user, tr_add_filter, None)
+    following_tasted_records_order = following_tasted_records.order_by("-id")
 
     p_add_filter = {"author__in": following_users, "created_at__gte": one_hour_ago}
     following_posts = get_post_feed_queryset(user, p_add_filter, None, None)
+    following_posts_order = following_posts.order_by("-id")
 
     # 2. 조회하지 않은 시음기록, 게시글
-    not_viewed_tasted_records = get_not_viewed_data(request, following_tasted_records, "tasted_record_viewed")
-    not_viewed_posts = get_not_viewed_data(request, following_posts, "post_viewed")
+    not_viewed_tasted_records = get_not_viewed_data(request, following_tasted_records_order, "tasted_record_viewed")
+    not_viewed_posts = get_not_viewed_data(request, following_posts_order, "post_viewed")
 
     # 3. 1 + 2
     combined_data = list(chain(not_viewed_tasted_records, not_viewed_posts))
@@ -162,11 +164,14 @@ def get_common_feed(request, user):
 
     # 1. 팔로우하지 않은 유저들의 시음기록, 게시글
     common_tasted_records = get_tasted_record_feed_queryset(user, add_filter, exclude_filter)
+    common_tasted_records_order = common_tasted_records.order_by("-id")
+
     common_posts = get_post_feed_queryset(user, None, exclude_filter, None)
+    common_posts_order = common_posts.order_by("-id")
 
     # 2. 조회하지 않은 시음기록, 게시글
-    not_viewd_tasted_records = get_not_viewed_data(request, common_tasted_records, "tasted_record_viewed")
-    not_viewd_posts = get_not_viewed_data(request, common_posts, "post_viewed")
+    not_viewd_tasted_records = get_not_viewed_data(request, common_tasted_records_order, "tasted_record_viewed")
+    not_viewd_posts = get_not_viewed_data(request, common_posts_order, "post_viewed")
 
     # 3. 1 + 2 (최신순 done)
     combined_data = list(chain(not_viewd_tasted_records, not_viewd_posts))
@@ -180,36 +185,50 @@ def get_refresh_feed(user):
     프라이빗한 시음기록은 제외
     """
 
-    is_user_liked_tasted_record_subquery = get_user_liked_tasted_record_queryset(user)
-    is_user_noted_tasted_record_subquery = get_user_noted_tasted_record_queryset(user)
+    tasted_records = get_tasted_record_feed_queryset(user, {"is_private": False}, None)
+    tasted_records_order = tasted_records.order_by("?")
 
-    tasted_records = (
+    posts = get_post_feed_queryset(user, None, None, None)
+    posts_order = posts.order_by("?")
+
+    combined_data = list(chain(tasted_records_order, posts_order))
+    random.shuffle(combined_data)
+
+    return combined_data
+
+
+def get_annonymous_tasted_records_feed():
+    return (
         TastedRecord.objects.filter(is_private=False)
         .select_related("author", "bean", "taste_review")
         .prefetch_related("comment_set", "note_set", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
         .annotate(
             likes=Count("like_cnt", distinct=True),
             comments=Count("comment", distinct=True),
-            is_user_liked=Exists(is_user_liked_tasted_record_subquery),
-            is_user_noted=Exists(is_user_noted_tasted_record_subquery),
+            is_user_liked=Value(False, output_field=BooleanField()),
+            is_user_noted=Value(False, output_field=BooleanField()),
         )
         .order_by("?")
     )
 
-    is_user_liked_post_subquery = get_user_liked_post_queryset(user)
-    is_user_noted_post_subquery = get_user_noted_post_queryset(user)
 
-    posts = (
+def get_annonymous_posts_feed():
+    return (
         Post.objects.select_related("author")
         .prefetch_related("tasted_records", "comment_set", "note_set", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
         .annotate(
             likes=Count("like_cnt", distinct=True),
             comments=Count("comment", distinct=True),
-            is_user_liked=Exists(is_user_liked_post_subquery),
-            is_user_noted=Exists(is_user_noted_post_subquery),
+            is_user_liked=Value(False, output_field=BooleanField()),
+            is_user_noted=Value(False, output_field=BooleanField()),
         )
         .order_by("?")
     )
+
+
+def annonymous_user_feed():
+    tasted_records = get_annonymous_tasted_records_feed()
+    posts = get_annonymous_posts_feed()
 
     combined_data = list(chain(tasted_records, posts))
     random.shuffle(combined_data)
@@ -226,12 +245,14 @@ def get_tasted_record_feed(request, user):
 
     # 1. 팔로우한 유저의 시음기록
     followed_tasted_records = get_tasted_record_feed_queryset(user, mixin_filter, None)
+    followed_tasted_records_order = followed_tasted_records.order_by("-id")
 
     # 2. 팔로우하지 않은 유저의 시음기록
     not_followed_tasted_records = get_tasted_record_feed_queryset(user, private_false_filter, following_users_filter)
+    not_followed_tasted_records_order = not_followed_tasted_records.order_by("-id")
 
     # 3. 1 + 2 (최신순 done)
-    tasted_records = list(chain(followed_tasted_records, not_followed_tasted_records))
+    tasted_records = list(chain(followed_tasted_records_order, not_followed_tasted_records_order))
 
     # 4. 조회하지 않은 시음기록
     not_viewd_tasted_records = get_not_viewed_data(request, tasted_records, "tasted_record_viewed")
@@ -258,12 +279,14 @@ def get_post_feed(request, user, subject):
     # 1. 팔로우한 유저의 게시글
     following_users_filter = {"author__in": following_users}
     followed_posts = get_post_feed_queryset(user, following_users_filter, None, subject)
+    followed_posts_order = followed_posts.order_by("-id")
 
     # 2. 팔로우하지 않은 유저의 게시글
     not_followed_posts = get_post_feed_queryset(user, None, following_users_filter, subject)
+    not_followed_posts_order = not_followed_posts.order_by("-id")
 
     # 3.  1 + 2 (최신순 done)
-    posts = list(chain(followed_posts, not_followed_posts))
+    posts = list(chain(followed_posts_order, not_followed_posts_order))
 
     # 4. 조회하지 않은 게시글
     not_viewed_posts = get_not_viewed_data(request, posts, "post_viewed")


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 

## 📝작업 내용

**비회원 사용자 지원 개선 및 페이지네이션**

1. 비회원 사용자 지원

- 랜덤 피드 제공: repo/records/services.py에 익명 사용자용 랜덤 피드를 제공하는 get_annonymous_tasted_records_feed와 get_annonymous_posts_feed 함수를 추가
- 피드 API 수정
  - FeedAPIView: 익명 사용자에게 랜덤 피드를 제공하기 위해, 새로운 함수와 페이지네이션 유틸리티를 적용했습니다.

2. 페이지네이션 기능 개선

- 유틸리티 함수 추가: repo/common/utils.py에 get_paginated_response_with_func와 get_paginated_response_with_class 함수를 추가하여, 함수 또는 클래스를 활용한 페이지네이션 응답을 간소화
- 뷰 업데이트
  - PostListCreateAPIView: 새로운 페이지네이션 유틸리티를 사용하고, 익명 사용자가 임의의 게시물을 볼 수 있도록 개선
  - TastedRecordListCreateAPIView: 페이지네이션 유틸리티를 사용하도록 업데이트하고, 익명 사용자가 랜덤 테이스팅 기록을 조회할 수 있도록 수정

3. 코드 리팩토링

- 직렬화 로직 분리: repo/records/services.py에서 여러 함수를 -id 정렬로 통일하고, 직렬화 로직을 전용 함수로 분리해 코드 가독성을 높였습니다.

페이지네이션 처리와 익명 사용자 지원을 강화하고, 직렬화 로직을 분리하여 코드 관리와 확장성을 높임