### PR TITLE
25 aws bucket meta data

### DIFF
--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -28,7 +28,7 @@ AWS_S3_REGION_NAME = env.str("AWS_S3_REGION_NAME", default="ap-northeast-2")
 AWS_S3_CUSTOM_DOMAIN = "%s.s3.%s.amazonaws.com" % (AWS_STORAGE_BUCKET_NAME, AWS_S3_REGION_NAME)
 MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/"
 AWS_S3_FILE_OVERWRITE = False
-AWS_DEFAULT_ACL = None
+AWS_DEFAULT_ACL = "public-read"
 
 STORAGES = {
     "default": {

--- a/repo/common/bucket.py
+++ b/repo/common/bucket.py
@@ -44,12 +44,11 @@ def delete_photo_from_s3(photo_url: str) -> None:
     Args:
         photo_url: 삭제할 이미지 URL
     """
-
-    s3 = boto3.client("s3", aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
-    s3_key = f"{AwsMediaStorage.location}/{photo_url.name}"
-
     try:
+        s3 = boto3.client("s3", aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY)
+        s3_key = f"{AwsMediaStorage.location}/{photo_url.name}"
+
         s3.delete_object(Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=s3_key)
     except Exception as e:
-        print(f"Failed to delete {s3_key} from S3: {e}")
+        raise e
     return None

--- a/repo/common/bucket.py
+++ b/repo/common/bucket.py
@@ -4,7 +4,9 @@ import boto3
 from django.conf import settings
 from storages.backends.s3boto3 import S3Boto3Storage, S3StaticStorage
 
-if not settings.DEBUG:
+DEBUG = settings.DEBUG
+
+if not DEBUG:
     AWS_S3_ACCESS_KEY_ID = settings.AWS_S3_ACCESS_KEY_ID
     AWS_S3_SECRET_ACCESS_KEY = settings.AWS_S3_SECRET_ACCESS_KEY
     AWS_STORAGE_BUCKET_NAME = settings.AWS_STORAGE_BUCKET_NAME
@@ -89,3 +91,13 @@ def delete_photo_from_s3(photo_url: str) -> None:
     except Exception as e:
         raise e
     return None
+
+
+def delete_profile_image(user):
+    if user.profile_image:
+        if DEBUG:
+            user.profile_image.delete(save=False)
+        else:
+            delete_photo_from_s3(user.profile_image)
+        user.profile_image = None
+        user.save()

--- a/repo/records/models.py
+++ b/repo/records/models.py
@@ -69,9 +69,19 @@ class Post(models.Model):
 
 
 class Photo(models.Model):
+    @staticmethod
+    def get_upload_path(instance, filename):
+        """업로드 경로를 동적으로 설정하는 함수"""
+
+        if instance.post:
+            return f"records/post/{instance.post.id}/{filename}"
+        elif instance.tasted_record:
+            return f"records/tasted_record/{instance.tasted_record.id}/{filename}"
+        return f"records/{filename}"
+
     post = models.ForeignKey(Post, on_delete=models.CASCADE, null=True, blank=True, verbose_name="관련 게시글")
     tasted_record = models.ForeignKey(TastedRecord, on_delete=models.CASCADE, null=True, blank=True, verbose_name="관련 시음 기록")
-    photo_url = models.ImageField(upload_to="records/", null=True, blank=True, verbose_name="사진")
+    photo_url = models.ImageField(upload_to=get_upload_path, null=True, blank=True, verbose_name="사진")
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="업로드 일자")
 
     def delete(self, *args, **kwargs):

--- a/repo/records/models.py
+++ b/repo/records/models.py
@@ -85,10 +85,10 @@ class Photo(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="업로드 일자")
 
     def delete(self, *args, **kwargs):
-        if settings.STORAGES["default"]["BACKEND"] == "repo.common.bucket.AwsMediaStorage":
-            delete_photo_from_s3(self.photo_url)  # S3에서 삭제
-        else:
+        if settings.DEBUG:
             self.photo_url.delete(save=False)  # 로컬에서 삭제
+        else:
+            delete_photo_from_s3(self.photo_url)  # S3에서 삭제
         super().delete(*args, **kwargs)
 
     def __str__(self):

--- a/repo/records/models.py
+++ b/repo/records/models.py
@@ -1,8 +1,6 @@
-from django.conf import settings
 from django.db import models
 
 from repo.beans.models import Bean, BeanTasteReview
-from repo.common.bucket import delete_photo_from_s3
 from repo.profiles.models import CustomUser
 from repo.records.managers import NoteManagers, PostManagers
 
@@ -83,13 +81,6 @@ class Photo(models.Model):
     tasted_record = models.ForeignKey(TastedRecord, on_delete=models.CASCADE, null=True, blank=True, verbose_name="관련 시음 기록")
     photo_url = models.ImageField(upload_to=get_upload_path, null=True, blank=True, verbose_name="사진")
     created_at = models.DateTimeField(auto_now_add=True, verbose_name="업로드 일자")
-
-    def delete(self, *args, **kwargs):
-        if settings.DEBUG:
-            self.photo_url.delete(save=False)  # 로컬에서 삭제
-        else:
-            delete_photo_from_s3(self.photo_url)  # S3에서 삭제
-        super().delete(*args, **kwargs)
 
     def __str__(self):
         return f"Photo: {self.id}"

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -15,7 +15,7 @@ Feed_Tag = "Feed"
 Like_Tage = "Like"
 Note_Tag = "Note"
 Comment_Tag = "Comment"
-Image_Tag = "Image"
+Photo_Tag = "Photo"
 Report_TAG = "Report"
 
 
@@ -257,8 +257,23 @@ class CommentDetailSchema:
     )
 
 
-class ImageSchema:
-    image_post_schema = extend_schema(
+class PhotoSchema:
+    photo_post_schema = extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="object_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                description="사진 업로드할 객체의 ID (PK)",
+            ),
+            OpenApiParameter(
+                name="object_type",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="사진 업로드할 객체의 타입",
+                enum=["post", "tasted_record"],
+            ),
+        ],
         request={
             "multipart/form-data": {
                 "type": "object",
@@ -293,11 +308,19 @@ class ImageSchema:
             400: OpenApiResponse(description="잘못된 데이터 형식 또는 유효성 검증 실패"),
         },
         summary="이미지 업로드 API",
-        description="여러 개의 이미지를 업로드하는 API. 업로드된 이미지는 고유 ID와 S3 URL로 반환됩니다.",
-        tags=[Image_Tag],
+        description="""
+            여러 개의 이미지를 업로드하는 API. 업로드된 이미지는 고유 ID와 S3 URL로 반환됩니다.
+            notice:
+            - 대표 사진은 요청 데이터의 첫 번째 이미지로 설정됩니다.
+            - 대표 사진의 파일명은 main_로 변경됩니다.
+            대표 사진 여부 판단요소:
+            - 사진명이 main_ 으로 시작합니다.
+            - 해당 사진 헤더의 메타데이터에 x-amz-meta-is-representative = true 입니다.
+        """,
+        tags=[Photo_Tag],
     )
 
-    image_delete_schema = extend_schema(
+    photo_delete_schema = extend_schema(
         parameters=[
             OpenApiParameter(
                 name="object_id",
@@ -327,7 +350,7 @@ class ImageSchema:
         tags=[Photo_Tag],
     )
 
-    image_schema_view = extend_schema_view(post=image_post_schema, delete=image_delete_schema)
+    photo_schema_view = extend_schema_view(post=photo_post_schema, delete=photo_delete_schema)
 
 
 class ReportSchema:

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -284,6 +284,7 @@ class ImageSchema:
                         "properties": {
                             "id": {"type": "integer", "example": 123},
                             "photo_url": {"type": "string", "example": "https://s3.amazonaws.com/bucket_name/uploads" "/photo1.jpg"},
+                            "is_representative": {"type": "boolean", "example": True},
                         },
                     },
                 },

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -300,21 +300,31 @@ class ImageSchema:
     image_delete_schema = extend_schema(
         parameters=[
             OpenApiParameter(
-                name="photo_id",
-                description="삭제할 사진의 ID 목록 (쿼리 파라미터로 여러 개의 photo_id 전달)",
-                required=True,
-                type={"type": "array", "items": {"type": "integer"}},
-            )
+                name="object_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                description="사진 삭제할 객체의 ID(PK)",
+            ),
+            OpenApiParameter(
+                name="object_type",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="사진 삭제할 객체의 타입",
+                enum=["post", "tasted_record"],
+            ),
         ],
         responses={
             204: OpenApiResponse(description="성공적으로 삭제됨"),
-            400: OpenApiResponse(description="잘못된 요청 (photo_id 누락 또는 잘못된 형식)"),
-            404: OpenApiResponse(description="해당 ID의 사진을 찾을 수 없음"),
+            400: OpenApiResponse(description="잘못된 요청 (object_id, object_type 누락 또는 잘못된 형식)"),
+            404: OpenApiResponse(description="해당 객체의 사진을 찾을 수 없음"),
             500: OpenApiResponse(description="서버 에러"),
         },
         summary="이미지 삭제 API",
-        description="여러 개의 이미지를 삭제하는 API. 삭제할 이미지의 ID를 쿼리 파라미터로 전달하면 해당 이미지가 삭제됩니다.",
-        tags=[Image_Tag],
+        description="""
+            삭제할 객체의 이미지들을 삭제하는 API.
+            삭제할 객체 타입과 해당 객체의 ID를 쿼리 파라미터로 전달하면 해당 이미지들이 삭제됩니다.
+        """,
+        tags=[Photo_Tag],
     )
 
     image_schema_view = extend_schema_view(post=image_post_schema, delete=image_delete_schema)

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -353,6 +353,58 @@ class PhotoSchema:
     photo_schema_view = extend_schema_view(post=photo_post_schema, delete=photo_delete_schema)
 
 
+class ProfilePhotoSchema:
+    profile_photo_post_schema = extend_schema(
+        request={
+            "multipart/form-data": {
+                "type": "object",
+                "properties": {
+                    "photo_url": {
+                        "type": "string",
+                        "format": "binary",
+                        "description": "프로필 이미지 파일",
+                    }
+                },
+                "required": ["photo_url"],
+            }
+        },
+        responses={
+            201: OpenApiResponse(
+                response={
+                    "type": "object",
+                    "properties": {
+                        "photo_url": {"type": "string", "example": "https://s3.amazonaws.com/bucket_name/profiles/main_uuid.jpg"}
+                    },
+                },
+                description="프로필 이미지 업로드 성공",
+            ),
+            400: OpenApiResponse(description="잘못된 요청"),
+            401: OpenApiResponse(description="인증되지 않은 사용자"),
+            500: OpenApiResponse(description="서버 에러"),
+        },
+        summary="프로필 이미지 업로드 API",
+        description="""
+            사용자의 프로필 이미지를 업로드하는 API
+            notice:
+            - 기존 프로필 이미지가 있다면 삭제됩니다. (수정시 기존 사진 삭제 후 업로드)
+        """,
+        tags=[Photo_Tag],
+    )
+
+    profile_photo_delete_schema = extend_schema(
+        responses={
+            204: OpenApiResponse(description="프로필 이미지 삭제 성공"),
+            401: OpenApiResponse(description="인증되지 않은 사용자"),
+            500: OpenApiResponse(description="서버 에러"),
+        },
+        summary="프로필 이미지 삭제 API",
+        description="사용자의 프로필 이미지를 삭제하는 API",
+        tags=[Photo_Tag],
+    )
+
+    profile_photo_schema_view = extend_schema_view(post=profile_photo_post_schema, delete=profile_photo_delete_schema)
+
+
 class ReportSchema:
     report_post_schema = extend_schema(
         request=ReportSerializer,

--- a/repo/records/urls.py
+++ b/repo/records/urls.py
@@ -10,6 +10,6 @@ urlpatterns = [
     path("comment/<int:id>", views.CommentDetailAPIView.as_view(), name="comment-detail"),
     path("comment/<str:object_type>/<int:object_id>", views.CommentApiView.as_view(), name="comment-list"),
     path("note/<str:object_type>/<int:object_id>/", views.NoteApiView.as_view(), name="note"),
-    path("image/", views.ImageApiView.as_view(), name="image-upload"),  # 이미지 업로드 테스트용
+    path("photo/<str:object_type>/<int:object_id>/", views.PhotoApiView.as_view(), name="photo-upload"),  # 이미지 업로드 테스트용
     path("report/", views.ReportApiView.as_view(), name="report"),
 ]

--- a/repo/records/urls.py
+++ b/repo/records/urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path("comment/<str:object_type>/<int:object_id>", views.CommentApiView.as_view(), name="comment-list"),
     path("note/<str:object_type>/<int:object_id>/", views.NoteApiView.as_view(), name="note"),
     path("photo/<str:object_type>/<int:object_id>/", views.PhotoApiView.as_view(), name="photo-upload"),  # 이미지 업로드 테스트용
+    path("profile/photo/", views.ProfilePhotoAPIView.as_view(), name="profile-photo"),
     path("report/", views.ReportApiView.as_view(), name="report"),
 ]

--- a/repo/records/urls.py
+++ b/repo/records/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path("comment/<int:id>", views.CommentDetailAPIView.as_view(), name="comment-detail"),
     path("comment/<str:object_type>/<int:object_id>", views.CommentApiView.as_view(), name="comment-list"),
     path("note/<str:object_type>/<int:object_id>/", views.NoteApiView.as_view(), name="note"),
-    path("photo/<str:object_type>/<int:object_id>/", views.PhotoApiView.as_view(), name="photo-upload"),  # 이미지 업로드 테스트용
-    path("profile/photo/", views.ProfilePhotoAPIView.as_view(), name="profile-photo"),
+    path("photo/<str:object_type>/<int:object_id>/", views.PhotoApiView.as_view(), name="photo-upload"),
+    path("photo/profile/", views.ProfilePhotoAPIView.as_view(), name="profile-photo"),
     path("report/", views.ReportApiView.as_view(), name="report"),
 ]

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -6,7 +6,7 @@ from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from repo.common.serializers import PhotoSerializer
+from repo.common.bucket import create_unique_filename
 from repo.common.utils import (
     delete,
     get_paginated_response_with_class,
@@ -189,44 +189,70 @@ class CommentDetailAPIView(APIView):
         return delete(request, id, Comment)
 
 
-@ImageSchema.image_schema_view
-class ImageApiView(APIView):
+@PhotoSchema.photo_schema_view
+class PhotoApiView(APIView):
     parser_classes = (MultiPartParser, FormParser)
 
-    def post(self, request):
+    def post(self, request, object_type, object_id):
         files = request.FILES.getlist("photo_url")
         if not files:
             return Response({"error": "photo_url is required"}, status=status.HTTP_400_BAD_REQUEST)
 
-        serializer = PhotoSerializer(data=[{"photo_url": file} for file in files], many=True)
-        if serializer.is_valid():
-            photos = serializer.save()
-            for photo in photos:
-                photo.save()
+        obj = get_post_or_tasted_record_detail(object_type, object_id)
+        photos = []
 
-            data = [{"id": photo.id, "photo_url": photo.photo_url.url} for photo in photos]
+        try:
+            for i, file in enumerate(files):
+                if i == 0:
+                    file.name = create_unique_filename(file.name, is_main=True)
+                else:
+                    file.name = create_unique_filename(file.name)
+
+                if object_type == "post":
+                    photo = Photo(post=obj, photo_url=file)
+                elif object_type == "tasted_record":
+                    photo = Photo(tasted_record=obj, photo_url=file)
+                else:
+                    raise ValueError("invalid object_type")
+
+                photo.save()
+                photos.append(photo)
+
+            data = [
+                {
+                    "id": photo.id,
+                    "photo_url": photo.photo_url.url,
+                    "is_representative": photo.photo_url.name.split("/")[-1].startswith("main_"),
+                }
+                for photo in photos
+            ]
 
             return Response(data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            # 업로드 실패 시 이미 저장된 사진들 삭제
+            for photo in photos:
+                photo.delete()
+            return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-    def delete(self, request):
-        photo_ids = request.query_params.getlist("photo_id")
-        if not photo_ids:
-            return Response({"error": "photo_id is required"}, status=status.HTTP_400_BAD_REQUEST)
+    def delete(self, request, object_type, object_id):
+        obj = get_post_or_tasted_record_detail(object_type, object_id)
+        if not obj:
+            return Response({"error": "object not found"}, status=status.HTTP_404_NOT_FOUND)
 
-        photos = Photo.objects.filter(id__in=photo_ids)
-        if not photos.exists():
-            return Response({"error": "photo not found"}, status=status.HTTP_404_NOT_FOUND)
+        if object_type == "post":
+            photos = obj.photo_set.all()
+        elif object_type == "tasted_record":
+            photos = obj.photo_set.all()
+        else:
+            return Response({"error": "invalid object_type"}, status=status.HTTP_400_BAD_REQUEST)
 
-        delete_cnt = 0
         try:
             for photo in photos:
                 photo.delete()
-                delete_cnt += 1
         except Exception as e:
             return Response({"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
-        return Response(f"{delete_cnt} photos deleted successfully", status=status.HTTP_204_NO_CONTENT)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 @ReportSchema.report_schema_view


### PR DESCRIPTION
## #️⃣연관된 이슈

> #25 

## 📝작업 내용

- 게시물 (게시글, 시음기록) 저장 경로 수정 
- 게시물에 해당하는 사진 수정, 삭제 기능 
- 프로필 사진 업로드, 삭제 API 추가
- 사진 대표사진 처리 (파일 접두어: 'main_', Meta data: is-represent : BOOL )
- local, prod 모두 고려함
- 사진 관련 API url 경로 수정 
- Spectacular 문서 업데이트 
