### PR TITLE
97 profiles 유저 도메인 서비스 로직 분리 및 수정 

### DIFF
--- a/repo/profiles/managers.py
+++ b/repo/profiles/managers.py
@@ -1,5 +1,3 @@
-import re
-
 from django.contrib.auth.models import BaseUserManager
 from django.db import models, transaction
 from django.db.models import Q
@@ -32,39 +30,6 @@ class CustomUserManager(BaseUserManager):
 
     def get_user_and_user_detail(self, id):
         return get_object_or_404(self.select_related("user_detail"), id=id)
-
-    def validate_nickname(self, nickname):
-        if not nickname or not nickname.strip():
-            raise ValueError("닉네임은 공백일 수 없습니다.")
-
-        if not re.match(r"^[가-힣a-zA-Z0-9]{2,12}$", nickname):
-            raise ValueError("닉네임은 2 ~ 12자의 한글, 영어, 숫자 중 하나 이상으로 구성되어야 합니다.")
-
-        # 닉네임 중복은 model에서 unique 제약조건 검사
-        return nickname
-
-    def set_user(self, user, validated_data):
-        if "nickname" in validated_data:
-            validated_data["nickname"] = self.validate_nickname(validated_data["nickname"])
-
-        for field in validated_data:
-            setattr(user, field, validated_data[field])
-        user.save()
-        return user
-
-
-class UserDetailManager(models.Manager):
-
-    def get_user_detail(self, user):
-        return self.get(user=user)
-
-    def set_user_detail(self, user, validated_data):
-        user_detail = self.get_user_detail(user)
-        for field in validated_data:
-            setattr(user_detail, field, validated_data[field])
-
-        user_detail.save()
-        return user_detail
 
 
 class RelationshipManager(models.Manager):

--- a/repo/profiles/models.py
+++ b/repo/profiles/models.py
@@ -1,12 +1,9 @@
-# create user model with additional fields
 from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
 from django.db import models
 
-# from profiles.managers import CustomUserManager
 from repo.profiles.managers import (
     CustomUserManager,
     RelationshipManager,
-    UserDetailManager,
 )
 
 
@@ -93,8 +90,6 @@ class UserDetail(models.Model):
     coffee_life = models.JSONField(default=default_coffee_life, verbose_name="커피 생활")
     preferred_bean_taste = models.JSONField(default=default_coffee_life, verbose_name="선호하는 원두 맛")
     is_certificated = models.BooleanField(default=False, verbose_name="인증 여부")
-
-    objects = UserDetailManager()
 
     def __str__(self):
         return f"{self.user.nickname}의 상세정보"

--- a/repo/profiles/schemas.py
+++ b/repo/profiles/schemas.py
@@ -28,6 +28,7 @@ class ProfileSchema:
         responses={
             200: UserProfileSerializer,
             401: OpenApiResponse(description="user not authenticated"),
+            404: OpenApiResponse(description="user not found"),
         },
         summary="자기 프로필 조회",
         description="""
@@ -43,7 +44,7 @@ class ProfileSchema:
         responses={
             200: UserProfileSerializer,
             400: OpenApiResponse(description="Bad Request"),
-            401: OpenApiResponse(description="Unauthorized"),
+            401: OpenApiResponse(description="user not authenticated"),
         },
         summary="자기 프로필 수정",
         description="""
@@ -65,7 +66,7 @@ class OtherProfileSchema:
         responses={
             200: UserProfileSerializer,
             401: OpenApiResponse(description="user not authenticated"),
-            404: OpenApiResponse(description="Not Found"),
+            404: OpenApiResponse(description="user not found"),
         },
         summary="상대 프로필 조회",
         description="""

--- a/repo/profiles/serializers.py
+++ b/repo/profiles/serializers.py
@@ -1,8 +1,7 @@
-import re
-
 from rest_framework import serializers
 
 from repo.profiles.models import CustomUser, UserDetail
+from repo.profiles.validators import UserValidator
 
 
 class UserRegisterSerializer(serializers.ModelSerializer):
@@ -30,9 +29,7 @@ class UserSignupSerializer(serializers.ModelSerializer):
         fields = ["nickname", "gender", "birth"]
 
     def validate_nickname(self, value):
-        if not re.match(r"^[가-힣0-9]{2,12}$", value):
-            raise serializers.ValidationError("닉네임은 2 ~ 12자의 한글 또는 숫자만 가능합니다.")
-        return value
+        return UserValidator.validate_nickname(value, instance=self.instance)
 
     def validate_gender(self, value):
         if value not in ["남", "여"]:
@@ -120,7 +117,12 @@ class UserDetailSerializer(serializers.ModelSerializer):
 
 class UserUpdateSerializer(serializers.ModelSerializer):
     user_detail = UserDetailSerializer(required=False)
+    nickname = serializers.CharField(required=False, allow_blank=True)
+
+    def validate_nickname(self, value):
+        UserValidator.validate_nickname(value, instance=self.instance)
+        return value
 
     class Meta:
         model = CustomUser
-        fields = ["nickname", "profile_image", "user_detail"]
+        fields = ["nickname", "user_detail"]

--- a/repo/profiles/services.py
+++ b/repo/profiles/services.py
@@ -1,19 +1,79 @@
 import random
 
-from django.db import models
-from django.db.models import Count, Exists, F, Value
+from django.db import models, transaction
+from django.db.models import Count, Exists, F, QuerySet, Value
 from rest_framework.generics import get_object_or_404
 
 from .models import CustomUser, Relationship, UserDetail
 
 
 class UserService:
-    def __init__(self, user_repository=None):
-        self.user_repository = user_repository or CustomUser.objects
+    def __init__(self, user_repo=CustomUser.objects, user_detail_repo=UserDetail.objects):
+        self.user_repo = user_repo
+        self.user_detail_repo = user_detail_repo
 
     def check_user_exists(self, id: int) -> bool:
         """유저 존재 여부 확인"""
-        return self.user_repository.filter(id=id).exists()
+        return self.user_repo.filter(id=id).exists()
+
+    def get_user_by_id(self, id: int) -> CustomUser:
+        """유저 조회"""
+        return get_object_or_404(self.user_repo, id=id)
+
+    def get_user_profile(self, user: CustomUser) -> dict:
+        """유저 프로필 조회"""
+        queryset = self.get_profile_base_queryset(user.id)
+        return queryset.filter(id=user.id).first()
+
+    def get_other_user_profile(self, user_id: int, other_user_id: int) -> dict:
+        """다른 유저 프로필 조회"""
+        is_user_following = Relationship.objects.check_relationship(user_id, other_user_id, "follow")
+        is_user_blocking = Relationship.objects.check_relationship(user_id, other_user_id, "block")
+
+        base_queryset = self.get_profile_base_queryset(user_id)
+        return (
+            base_queryset.filter(id=other_user_id)
+            .annotate(
+                is_user_following=Value(is_user_following),
+                is_user_blocking=Value(is_user_blocking),
+            )
+            .first()
+        )
+
+    def get_profile_base_queryset(self, id: int) -> QuerySet:
+        """유저 프로필 기본 쿼리셋 조회"""
+        follower_cnt = Relationship.objects.followers(id).count()
+        following_cnt = Relationship.objects.following(id).count()
+
+        return self.user_repo.select_related("user_detail").annotate(
+            introduction=F("user_detail__introduction"),
+            profile_link=F("user_detail__profile_link"),
+            coffee_life=F("user_detail__coffee_life"),
+            following_cnt=Value(follower_cnt),
+            follower_cnt=Value(following_cnt),
+            post_cnt=Count("post"),
+        )
+
+    @transaction.atomic
+    def update_user(self, user: CustomUser, validated_data: dict) -> CustomUser:
+        """유저 정보를 업데이트"""
+        if nickname := validated_data.get("nickname"):
+            user.nickname = nickname
+
+        if user_detail_data := validated_data.get("user_detail"):
+            self._update_user_detail(user, user_detail_data)
+
+        user.save()
+        return user
+
+    def _update_user_detail(self, user: CustomUser, validated_data: dict) -> UserDetail:
+        """유저 상세 정보를 업데이트"""
+        user_detail = self.user_detail_repo.get(user=user)
+        for field, value in validated_data.items():
+            setattr(user_detail, field, value)
+
+        user_detail.save()
+        return user_detail
 
 
 class CoffeeLifeCategoryService:
@@ -36,36 +96,6 @@ class CoffeeLifeCategoryService:
         true_categories = [c for c in self.default_categories if user_detail.coffee_life[c]]
 
         return random.choice(true_categories)
-
-
-def base_user_profile_query(id):
-    follower_cnt = Relationship.objects.followers(id).count()
-    following_cnt = Relationship.objects.following(id).count()
-
-    return CustomUser.objects.select_related("user_detail").annotate(
-        introduction=F("user_detail__introduction"),
-        profile_link=F("user_detail__profile_link"),
-        coffee_life=F("user_detail__coffee_life"),
-        following_cnt=Value(follower_cnt),
-        follower_cnt=Value(following_cnt),
-        post_cnt=Count("post"),
-    )
-
-
-def get_user_profile(id):
-    return base_user_profile_query(id).filter(id=id).first()
-
-
-def get_other_user_profile(request_user_id, other_user_id):
-    is_user_following = Relationship.objects.check_relationship(request_user_id, other_user_id, "follow")
-    is_user_blocking = Relationship.objects.check_relationship(request_user_id, other_user_id, "block")
-
-    return (
-        base_user_profile_query(request_user_id)
-        .filter(id=other_user_id)
-        .annotate(is_user_following=Value(is_user_following), is_user_blocking=Value(is_user_blocking))
-        .first()
-    )
 
 
 def get_following_list(user):

--- a/repo/profiles/validators.py
+++ b/repo/profiles/validators.py
@@ -1,0 +1,33 @@
+import re
+
+from repo.common.exception.exceptions import ValidationException
+from repo.profiles.models import CustomUser
+
+
+class UserValidator:
+    """사용자 유효성 검사를 위한 Validator 클래스"""
+
+    @staticmethod
+    def validate_nickname(value, instance=None):
+        """닉네임 유효성 검사"""
+
+        if not value and value is not None:
+            raise ValidationException(
+                detail="닉네임은 공백일 수 없습니다.",
+                code="nickname_invalid",
+            )
+
+        if not re.match(r"^[가-힣a-zA-Z0-9]{2,12}$", value):
+            raise ValidationException(
+                detail="닉네임은 2 ~ 12자의 한글 영어 또는 숫자만 가능합니다.",
+                code="nickname_invalid",
+            )
+
+        is_nickname_exists = CustomUser.objects.filter(nickname=value).exclude(pk=instance.pk if instance else None).exists()
+        if is_nickname_exists:
+            raise ValidationException(
+                detail="이미 존재하는 닉네임입니다.",
+                code="nickname_invalid",
+            )
+
+        return value

--- a/tests/profiles/profile_info_tests.py
+++ b/tests/profiles/profile_info_tests.py
@@ -69,8 +69,10 @@ class TestMyProfileAPIView:
 
         # Then
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.data["message"] == "Authentication credentials were not provided."
+        assert response.data["code"] == "not_authenticated"
 
-    def test_patch_my_profile_emptry_nickname_data(self, authenticated_client):
+    def test_patch_my_profile_empty_nickname_data(self, authenticated_client):
         """
         잘못된 데이터로 프로필 수정 실패 테스트
         """
@@ -81,14 +83,15 @@ class TestMyProfileAPIView:
 
         # When
         invalid_data = {
-            "nickname": "",  # 빈 문자열은 유효하지 않음
+            "nickname": " ",
         }
 
         response = client.patch(url, data=invalid_data, format="json")
 
         # Then
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["error"] == "닉네임은 공백일 수 없습니다."  # msg from model manager
+        assert response.data["message"] == "닉네임은 공백일 수 없습니다."
+        assert response.data["code"] == "nickname_invalid"
 
     def test_patch_my_profile_nickname_already_exists(self, authenticated_client):
         """
@@ -111,8 +114,8 @@ class TestMyProfileAPIView:
 
         # Then
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.data["nickname"][0] == "사용자 with this 닉네임 already exists."  # msg from db
-        assert response.data["nickname"][0].code == "unique"
+        assert response.data["message"] == "닉네임은 2 ~ 12자의 한글 영어 또는 숫자만 가능합니다."
+        assert response.data["code"] == "nickname_invalid"
 
 
 class TestOtherProfileAPIView:
@@ -154,3 +157,5 @@ class TestOtherProfileAPIView:
 
         # Then
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+        assert response.data["message"] == "Authentication credentials were not provided."
+        assert response.data["code"] == "not_authenticated"


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91  #92 #97 

## 📝작업 내용
주요 커밋 1ab70c8a7d6ca44813c7568db57996861727d5c8
- UserService를 사용하여 비지니스 로직 캡슐화
- 의존성 주입
- 타입힌팅

- UserDetailManager 제거 및 관련 로직을 UserService로 이동
- 닉네임 유효성 검사 로직을 별도의 Validator로 분리
- 프로필 업데이트 로직을 트랜잭션으로 처리하도록 개선
- CustomUserManager에서 불필요한 메서드 제거
- 에러 응답 형식 통일화
