### PR TITLE
99 interaction note service

### DIFF
--- a/repo/interactions/admin.py
+++ b/repo/interactions/admin.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 
+from repo.interactions.note.models import Note
 from repo.interactions.relationship.models import Relationship
 
 admin.site.register(Relationship)
+admin.site.register(Note)

--- a/repo/interactions/note/models.py
+++ b/repo/interactions/note/models.py
@@ -1,0 +1,21 @@
+from django.db import models
+
+from repo.beans.models import Bean
+from repo.profiles.models import CustomUser
+from repo.records.models import Post, TastedRecord
+
+
+class Note(models.Model):
+    author = models.ForeignKey(CustomUser, on_delete=models.CASCADE, verbose_name="작성자")
+    post = models.ForeignKey(Post, null=True, blank=True, on_delete=models.CASCADE, verbose_name="게시글")
+    tasted_record = models.ForeignKey(TastedRecord, null=True, blank=True, on_delete=models.CASCADE, verbose_name="시음 기록")
+    bean = models.ForeignKey(Bean, null=True, blank=True, on_delete=models.CASCADE, verbose_name="원두")
+    created_at = models.DateTimeField(auto_now_add=True, verbose_name="작성일")
+
+    def __str__(self):
+        return f"Note: {self.id}"
+
+    class Meta:
+        db_table = "note"
+        verbose_name = "노트"
+        verbose_name_plural = "노트"

--- a/repo/interactions/note/schemas.py
+++ b/repo/interactions/note/schemas.py
@@ -1,0 +1,99 @@
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import (
+    OpenApiParameter,
+    OpenApiResponse,
+    extend_schema,
+    extend_schema_view,
+)
+
+from .serializers import NoteResponseSerializer
+
+Note_Tag = "Note"
+
+
+class NoteSchema:
+    note_post_schema = extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="object_type",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="object type",
+                enum=["post", "tasted_record", "bean"],
+            ),
+            OpenApiParameter(
+                name="object_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                description="object id",
+            ),
+        ],
+        responses={
+            201: NoteResponseSerializer,
+            400: OpenApiResponse(description="잘못된 요청 (유효하지 않은 object_type 또는 object_id)"),
+            401: OpenApiResponse(description="인증되지 않은 사용자"),
+            404: OpenApiResponse(description="대상 객체를 찾을 수 없음"),
+            409: OpenApiResponse(description="이미 노트가 존재함"),
+        },
+        summary="노트 생성",
+        description="""
+            사용자가 특정 컨텐츠(게시글, 시음기록, 원두)에 대해 노트를 생성
+
+            **Path Parameters:**
+            - object_type (string): "post" 또는 "tasted_record" 또는 "bean"
+            - object_id (integer): 노트를 생성할 대상 객체의 ID
+
+            **응답 코드:**
+            - 201: 노트 생성 성공
+            - 400: 잘못된 요청 (유효하지 않은 object_type 또는 object_id)
+            - 401: 인증되지 않은 사용자
+            - 404: 대상 객체를 찾을 수 없음
+            - 409: 이미 해당 객체에 대한 노트가 존재함
+
+            담당자: hwstar1204
+        """,
+        tags=[Note_Tag],
+    )
+
+    note_delete_schema = extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="object_type",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.PATH,
+                description="object type",
+                enum=["post", "tasted_record", "bean"],
+            ),
+            OpenApiParameter(
+                name="object_id",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.PATH,
+                description="object id",
+            ),
+        ],
+        responses={
+            204: OpenApiResponse(description="노트 삭제 성공"),
+            400: OpenApiResponse(description="잘못된 요청 (유효하지 않은 object_type 또는 object_id)"),
+            401: OpenApiResponse(description="인증되지 않은 사용자"),
+            404: OpenApiResponse(description="노트를 찾을 수 없음"),
+        },
+        summary="노트 삭제",
+        description="""
+            사용자가 생성한 노트를 삭제
+
+            **Path Parameters:**
+            - object_type (string): "post" 또는 "tasted_record" 또는 "bean"
+            - object_id (integer): 노트를 삭제할 대상 객체의 ID
+
+            **응답 코드:**
+            - 204: 노트 삭제 성공
+            - 400: 잘못된 요청 (유효하지 않은 object_type 또는 object_id)
+            - 401: 인증되지 않은 사용자
+            - 404: 노트를 찾을 수 없음
+
+            담당자: hwstar1204
+        """,
+        tags=[Note_Tag],
+    )
+
+    note_schema_view = extend_schema_view(post=note_post_schema, delete=note_delete_schema)

--- a/repo/interactions/note/serializers.py
+++ b/repo/interactions/note/serializers.py
@@ -1,0 +1,42 @@
+from rest_framework import serializers
+
+from repo.beans.models import Bean
+from repo.common.exception.exceptions import ValidationException
+from repo.records.models import Post, TastedRecord
+
+from .models import Note
+
+VALID_OBJECT_TYPES = ["post", "tasted_record", "bean"]
+
+
+class NoteCreateSerializer(serializers.Serializer):
+    object_type = serializers.ChoiceField(choices=VALID_OBJECT_TYPES)
+    object_id = serializers.IntegerField(min_value=1)
+
+    def validate(self, data):
+        """
+        객체 타입, 존재 여부 검증
+        """
+        object_type = data["object_type"]
+        object_id = data["object_id"]
+
+        model_map = {"post": Post, "tasted_record": TastedRecord, "bean": Bean}
+
+        if object_type not in VALID_OBJECT_TYPES:
+            raise ValidationException(message=f"Invalid object type: {object_type}", code="invalid_object_type")
+
+        model = model_map[object_type]
+        if not model.objects.filter(id=object_id).exists():
+            raise ValidationException(message=f"{object_type} with id {object_id} does not exist", code="object_not_found")
+
+        return data
+
+
+class NoteResponseSerializer(serializers.ModelSerializer):
+    post = serializers.IntegerField(source="post.id", required=False)
+    tasted_record = serializers.IntegerField(source="tasted_record.id", required=False)
+    bean = serializers.IntegerField(source="bean.id", required=False)
+
+    class Meta:
+        model = Note
+        fields = "__all__"

--- a/repo/interactions/note/services.py
+++ b/repo/interactions/note/services.py
@@ -1,0 +1,35 @@
+from repo.beans.models import Bean
+from repo.common.exception.exceptions import ConflictException, NotFoundException
+from repo.records.models import Post, TastedRecord
+
+from .models import Note
+
+
+class NoteService:
+    def __init__(self, note_repo=Note.objects):
+        self.note_repo = note_repo
+
+    def is_existing_note(self, user, object_type, object_id):
+        return self.note_repo.filter(author=user, **{f"{object_type}__id": object_id}).exists()
+
+    def _get_instance(self, object_type, object_id):
+        model_map = {"post": Post, "tasted_record": TastedRecord, "bean": Bean}
+        return model_map[object_type].objects.get(id=object_id)
+
+    def create(self, user, object_type, object_id):
+        if self.is_existing_note(user, object_type, object_id):
+            raise ConflictException(detail="Note already exists", code="note_exists")
+
+        instance = self._get_instance(object_type, object_id)
+        note = self.note_repo.create(author=user, **{f"{object_type}": instance})
+        return note
+
+    def delete(self, user, object_type, object_id):
+        instance = self._get_instance(object_type, object_id)
+        note = self.note_repo.filter(author=user, **{f"{object_type}": instance}).first()
+
+        if not note:
+            raise NotFoundException(detail="Note not found", code="note_not_found")
+
+        note.delete()
+        return note

--- a/repo/interactions/note/urls.py
+++ b/repo/interactions/note/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("<str:object_type>/<int:object_id>/", views.NoteApiView.as_view(), name="note"),
+]

--- a/repo/interactions/note/views.py
+++ b/repo/interactions/note/views.py
@@ -1,0 +1,34 @@
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .schemas import NoteSchema
+from .serializers import NoteCreateSerializer, NoteResponseSerializer
+from .services import NoteService
+
+
+@NoteSchema.note_schema_view
+class NoteApiView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def __init__(self, **kwargs):
+        self.note_service = NoteService()
+
+    def post(self, request, object_type, object_id):
+        path_params = {"object_type": object_type, "object_id": object_id}
+        serializer = NoteCreateSerializer(data=path_params)
+        serializer.is_valid(raise_exception=True)
+
+        note = self.note_service.create(request.user, object_type, object_id)
+        response_serializer = NoteResponseSerializer(note)
+
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+    def delete(self, request, object_type, object_id):
+        path_params = {"object_type": object_type, "object_id": object_id}
+        serializer = NoteCreateSerializer(data=path_params)
+        serializer.is_valid(raise_exception=True)
+
+        self.note_service.delete(request.user, object_type, object_id)
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/repo/interactions/urls.py
+++ b/repo/interactions/urls.py
@@ -2,4 +2,5 @@ from django.urls import include, path
 
 urlpatterns = [
     path("relationship/", include("repo.interactions.relationship.urls")),
+    path("note/", include("repo.interactions.note.urls")),
 ]

--- a/repo/records/admin.py
+++ b/repo/records/admin.py
@@ -1,9 +1,8 @@
 from django.contrib import admin
 
-from .models import Comment, Note, Photo, Post, TastedRecord
+from .models import Comment, Photo, Post, TastedRecord
 
 admin.site.register(TastedRecord)
 admin.site.register(Post)
 admin.site.register(Photo)
 admin.site.register(Comment)
-admin.site.register(Note)

--- a/repo/records/models.py
+++ b/repo/records/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 from repo.beans.models import Bean, BeanTasteReview
 from repo.profiles.models import CustomUser
-from repo.records.managers import NoteManagers, PostManagers
+from repo.records.managers import PostManagers
 
 
 class TastedRecord(models.Model):
@@ -98,25 +98,6 @@ class Comment(models.Model):
         db_table = "comment"
         verbose_name = "댓글"
         verbose_name_plural = "댓글"
-
-
-class Note(models.Model):
-    author = models.ForeignKey(CustomUser, on_delete=models.CASCADE, verbose_name="작성자")
-    post = models.ForeignKey(Post, null=True, blank=True, on_delete=models.CASCADE, verbose_name="게시글")
-    tasted_record = models.ForeignKey(TastedRecord, null=True, blank=True, on_delete=models.CASCADE, verbose_name="시음 기록")
-    bean = models.ForeignKey(Bean, null=True, blank=True, on_delete=models.CASCADE, verbose_name="원두")
-    created_at = models.DateTimeField(auto_now_add=True, verbose_name="작성일")
-
-    # objects = models.Manager()  # The default manager
-    objects = NoteManagers()
-
-    def __str__(self):
-        return f"Note: {self.id}"
-
-    class Meta:
-        db_table = "note"
-        verbose_name = "노트"
-        verbose_name_plural = "노트"
 
 
 class Report(models.Model):

--- a/repo/records/schemas.py
+++ b/repo/records/schemas.py
@@ -13,7 +13,6 @@ from repo.records.tasted_record.serializers import TastedRecordListSerializer
 
 Feed_Tag = "Feed"
 Like_Tage = "Like"
-Note_Tag = "Note"
 Comment_Tag = "Comment"
 Photo_Tag = "Photo"
 Report_TAG = "Report"
@@ -130,40 +129,6 @@ class LikeSchema:
     )
 
     like_schema_view = extend_schema_view(post=like_post_schema, delete=like_delete_schema)
-
-
-class NoteSchema:
-    note_post_schema = extend_schema(
-        responses={
-            200: OpenApiResponse(description="Note already exists"),
-            201: OpenApiResponse(description="Note created"),
-        },
-        summary="노트 생성",
-        description="""
-            object_type : "post" 또는 "tasted_record" 또는 "bean"
-            object_id : 노트를 처리할 객체의 ID
-
-            담당자: hwstar1204
-        """,
-        tags=[Note_Tag],
-    )
-
-    note_delete_schema = extend_schema(
-        responses={
-            200: OpenApiResponse(description="Note deleted"),
-            404: OpenApiResponse(description="Note not found"),
-        },
-        summary="노트 삭제",
-        description="""
-            object_type : "post" 또는 "tasted_record" 또는 "bean"
-            object_id : 노트를 처리할 객체의 ID
-
-            담당자: hwstar1204
-        """,
-        tags=[Note_Tag],
-    )
-
-    note_schema_view = extend_schema_view(post=note_post_schema, delete=note_delete_schema)
 
 
 class CommentSchema:

--- a/repo/records/serializers.py
+++ b/repo/records/serializers.py
@@ -1,8 +1,9 @@
 from rest_framework import serializers
 
 from repo.common.utils import get_time_difference
+from repo.interactions.note.models import Note
 from repo.profiles.serializers import UserSimpleSerializer
-from repo.records.models import Comment, Note, Post, Report, TastedRecord
+from repo.records.models import Comment, Post, Report, TastedRecord
 from repo.records.posts.serializers import PostListSerializer
 from repo.records.services import get_post_or_tasted_record_or_comment
 from repo.records.tasted_record.serializers import TastedRecordListSerializer

--- a/repo/records/urls.py
+++ b/repo/records/urls.py
@@ -9,7 +9,6 @@ urlpatterns = [
     path("like/<str:object_type>/<int:object_id>/", views.LikeApiView.as_view(), name="records-likes"),
     path("comment/<int:id>/", views.CommentDetailAPIView.as_view(), name="comment-detail"),
     path("comment/<str:object_type>/<int:object_id>/", views.CommentApiView.as_view(), name="comment-list"),
-    path("note/<str:object_type>/<int:object_id>/", views.NoteApiView.as_view(), name="note"),
     path("photo/", views.PhotoApiView.as_view(), name="photo-upload"),
     path("photo/profile/", views.ProfilePhotoAPIView.as_view(), name="profile-photo"),
     path("report/", views.ReportApiView.as_view(), name="report"),

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -24,7 +24,7 @@ from repo.common.utils import (
     get_paginated_response_with_class,
     get_paginated_response_with_func,
 )
-from repo.records.models import Comment, Note, Photo, Post, Report, TastedRecord
+from repo.records.models import Comment, Photo, Post, Report, TastedRecord
 from repo.records.schemas import *
 from repo.records.serializers import CommentSerializer, ReportSerializer
 from repo.records.services import (
@@ -85,30 +85,6 @@ class LikeApiView(APIView):
 
         obj.like_cnt.remove(user_id)
         return Response({"detail": "like deleted"}, status=status.HTTP_204_NO_CONTENT)
-
-
-@NoteSchema.note_schema_view
-class NoteApiView(APIView):
-    permission_classes = [IsAuthenticated]
-
-    def post(self, request, object_type, object_id):
-        user = request.user
-
-        existing_note = Note.objects.existing_note(user, object_type, object_id)
-        if existing_note:
-            return Response({"detail": "note already exists"}, status=status.HTTP_200_OK)
-
-        Note.objects.create_note_for_object(user, object_type, object_id)
-        return Response({"detail": "note created"}, status=status.HTTP_201_CREATED)
-
-    def delete(self, request, object_type, object_id):
-        user = request.user
-
-        existing_note = Note.objects.existing_note(user, object_type, object_id)
-        if existing_note:
-            existing_note.delete()
-            return Response({"detail": "note deleted"}, status=status.HTTP_200_OK)
-        return Response({"detail": "note not found"}, status=status.HTTP_404_NOT_FOUND)
 
 
 @CommentSchema.comment_schema_view

--- a/tests/factorys.py
+++ b/tests/factorys.py
@@ -5,9 +5,10 @@ from factory.django import DjangoModelFactory
 from faker import Faker
 
 from repo.beans.models import Bean, BeanTasteReview
+from repo.interactions.note.models import Note
 from repo.interactions.relationship.models import Relationship
 from repo.profiles.models import CustomUser, UserDetail
-from repo.records.models import Comment, Note, Photo, Post, Report, TastedRecord
+from repo.records.models import Comment, Photo, Post, Report, TastedRecord
 
 fake = Faker("ko_KR")
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #91 #92 #99 

## 📝작업 내용
`repo/interactions` 모듈에 새로운 `Note` 기능을 추가하는 변경 사항을 포함하고 있습니다.
`Note` 기능은 모델, 직렬화기(Serializer), 뷰(View), 스키마(Schema) 등을 포함하며, 기존의 `repo/records` 모듈에서 `Note` 모델을 제거하고 리팩토링하는 작업도 포함됩니다.

### 주요 변경 사항

1. **`Note` 기능 도입**
   - **모델 추가**: `repo/interactions/note/models.py`에 `Note` 모델이 추가되었습니다. 이 모델은 `author`, `post`, `tasted_record`, `bean`, `created_at` 필드를 포함합니다.
   - **직렬화기 추가**: `repo/interactions/note/serializers.py`에서는 `NoteCreateSerializer`와 `NoteResponseSerializer`를 생성하여 `Note` 생성과 응답 직렬화를 처리합니다.
   - **뷰 추가**: `repo/interactions/note/views.py`에서는 `NoteApiView` 클래스를 추가해 `POST`와 `DELETE` 요청을 처리하여 노트를 생성하고 삭제합니다.
   - **스키마 정의**: `repo/interactions/note/schemas.py`에서는 `NoteSchema`를 정의하고, 노트를 생성하거나 삭제할 때 사용할 스키마 뷰를 추가했습니다.
   - **서비스 클래스**: `repo/interactions/note/services.py`에서는 `NoteService` 클래스를 구현해 노트 생성 및 삭제 로직을 관리합니다.

2. **`repo/records` 모듈에서 `Note` 모델 제거**
   - `repo/records/models.py`에서 `Note` 모델과 관련된 매니저를 제거했습니다.
   - `repo/records/admin.py`에서는 `Note` 모델을 더 이상 관리자 인터페이스에 등록하지 않게 되었습니다.
   - `repo/records/serializers.py`, `repo/records/schemas.py`, `repo/records/views.py`에서도 `Note`와 관련된 코드들을 삭제했습니다.

3. **URL 및 테스트 업데이트**
   - `repo/interactions/urls.py`에서는 새로운 `Note` 엔드포인트를 위한 URL 패턴을 추가했습니다.
   - `tests/interactions/note_tests.py`에서는 새로운 `Note` 엔드포인트와 변경된 응답 처리 방식을 반영하여 테스트를 업데이트했습니다.

### 요약
이 변경 사항은 `Note` 기능을 `repo/interactions` 모듈로 옮기고, `repo/records`에서 이를 제거하는 리팩토링 작업입니다. 새로운 모델, 직렬화기, 뷰, 서비스, 스키마가 추가되었으며, 관련된 URL과 테스트도 업데이트되었습니다.