### PR TITLE
Pre works 104 records post service

### DIFF
--- a/repo/common/view_counter.py
+++ b/repo/common/view_counter.py
@@ -59,3 +59,18 @@ def get_viewed_contents(request, cookie_name):
     """
     viewed_contents = json.loads(request.COOKIES.get(cookie_name, "[]"))
     return viewed_contents
+
+
+def get_not_viewed_contents(request, queryset, cookie_name):
+    """
+    사용자가 아직 조회하지 않은 데이터만 필터링하여 반환합니다.
+
+    Args:
+        request: HTTP 요청 객체
+        queryset: 필터링할 쿼리셋
+        cookie_name: 조회 여부를 확인할 쿠키 이름
+
+    Returns:
+        list: 조회하지 않은 데이터 리스트
+    """
+    return [content for content in queryset if not is_viewed(request, cookie_name=cookie_name, content_id=content.id)]

--- a/repo/interactions/like/services.py
+++ b/repo/interactions/like/services.py
@@ -1,3 +1,5 @@
+from django.db.models import OuterRef
+
 from repo.common.exception.exceptions import (
     ConflictException,
     NotFoundException,
@@ -16,16 +18,22 @@ class LikeService:
 
     model_map = {"post": Post, "tasted_record": TastedRecord, "comment": Comment}
 
-    def __init__(self, object_type: str, object_id: int):
+    def __init__(self, object_type: str, object_id: int = None):
         self.like_repo = self._set_like_object(object_type, object_id)
+        self.target_model = self.model_map[object_type]
+        self.object_type = object_type
+        self.object_id = object_id
 
     def _set_like_object(self, object_type: str, object_id: int):
         if object_type not in self.model_map:
             raise ValidationException(detail="Invalid object type", code="validation_error")
 
+        if object_id is None:  # 좋아요 대상 객체가 없는 경우
+            return None
+
         try:
-            return self.model_map[object_type].objects.get(id=object_id)
-        except self.model_map[object_type].DoesNotExist as e:
+            return self.target_model.objects.get(id=object_id)
+        except self.target_model.DoesNotExist as e:
             raise NotFoundException(detail="object not found", code="not_found") from e
 
     def increase_like(self, user_id: int) -> None:
@@ -51,3 +59,9 @@ class LikeService:
     def is_user_liked(self, user_id: int) -> bool:
         """사용자가 좋아요를 눌렀는지 여부 반환"""
         return self.like_repo.like_cnt.filter(id=user_id).exists()
+
+    def get_like_subquery_for_post(self, user):
+        return self.target_model.like_cnt.through.objects.filter(post_id=OuterRef("pk"), customuser_id=user.id)
+
+    def get_like_subquery_for_tasted_record(self, user):
+        return self.target_model.like_cnt.through.objects.filter(tastedrecord_id=OuterRef("pk"), customuser_id=user.id)

--- a/repo/interactions/like/services.py
+++ b/repo/interactions/like/services.py
@@ -14,25 +14,29 @@ class LikeService:
 
     Attributes:
         like_repo: 좋아요 대상 객체 (Post, TastedRecord, Comment)
+        target_model: 좋아요 대상 모델 클래스
+        object_type: 좋아요 대상 객체 타입
+        object_id: 좋아요 대상 객체 ID
     """
 
     model_map = {"post": Post, "tasted_record": TastedRecord, "comment": Comment}
 
     def __init__(self, object_type: str, object_id: int = None):
-        self.like_repo = self._set_like_object(object_type, object_id)
-        self.target_model = self.model_map[object_type]
-        self.object_type = object_type
-        self.object_id = object_id
-
-    def _set_like_object(self, object_type: str, object_id: int):
         if object_type not in self.model_map:
             raise ValidationException(detail="Invalid object type", code="validation_error")
 
-        if object_id is None:  # 좋아요 대상 객체가 없는 경우
+        self.target_model = self.model_map[object_type]
+        self.object_type = object_type
+        self.object_id = object_id
+        self.like_repo = self._set_like_object()
+
+    def _set_like_object(self) -> Post | TastedRecord | Comment | None:
+        """좋아요 대상 객체 설정"""
+        if self.object_id is None:  # 좋아요 대상 객체가 없는 경우
             return None
 
         try:
-            return self.target_model.objects.get(id=object_id)
+            return self.target_model.objects.get(id=self.object_id)
         except self.target_model.DoesNotExist as e:
             raise NotFoundException(detail="object not found", code="not_found") from e
 

--- a/repo/interactions/note/services.py
+++ b/repo/interactions/note/services.py
@@ -1,3 +1,5 @@
+from django.db.models import OuterRef
+
 from repo.beans.models import Bean
 from repo.common.exception.exceptions import ConflictException, NotFoundException
 from repo.records.models import Post, TastedRecord
@@ -33,3 +35,9 @@ class NoteService:
 
         note.delete()
         return note
+
+    def get_note_subquery_for_post(self, user):
+        return self.note_repo.filter(author=user, post_id=OuterRef("pk"))
+
+    def get_note_subquery_for_tasted_record(self, user):
+        return self.note_repo.filter(author=user, tasted_record_id=OuterRef("pk"))


### PR DESCRIPTION
## #️⃣연관된 이슈

> #104 

## 📝작업 내용
이 풀 리퀘스트는 `repo` 모듈의 기능 향상 및 구조 개선을 위한 여러 변경 사항을 포함하고 있습니다. 주요 변경 사항은 다음과 같습니다:

1. **Like/Note 서비스 리팩토링**:
   - `LikeService`와 `NoteService`에 새로운 서브쿼리 메소드 추가:
     - `get_like_subquery_for_post`, `get_like_subquery_for_tasted_record`
     - `get_note_subquery_for_post`, `get_note_subquery_for_tasted_record`
   - `LikeService` 클래스에 `target_model`, `object_type`, `object_id` 속성 추가 및 초기화 로직 리팩토링.

2. **View Counter 유틸리티 업데이트**:
   - `get_not_viewed_data` 함수를 `view_counter.py`로 이동하고 이름을 `get_not_viewed_contents`로 변경.
   - `repo/records/services.py`에서 이 함수를 사용하는 코드 업데이트.

3. **코드 정리 및 임포트 수정**:
   - `repo/records/services.py`에서 중복된 메소드 제거 및 임포트 정리.
   - `like/services.py`, `note/services.py`에 `OuterRef` 임포트 추가.

이 변경은 코드의 가독성, 유지보수성을 개선하고, 서비스 로직을 더 효율적으로 처리할 수 있게 합니다.