### PR TITLE
104 records post service

### DIFF
--- a/repo/profiles/schemas.py
+++ b/repo/profiles/schemas.py
@@ -1,5 +1,4 @@
 from drf_spectacular.utils import (
-    OpenApiParameter,
     OpenApiResponse,
     extend_schema,
     extend_schema_view,
@@ -9,8 +8,6 @@ from repo.profiles.serializers import (
     UserProfileSerializer,
     UserUpdateSerializer,
 )
-from repo.records.models import Post
-from repo.records.posts.serializers import UserPostSerializer
 from repo.records.serializers import UserNoteSerializer
 
 Profile_Tag = "profiles"
@@ -74,29 +71,6 @@ class OtherProfileSchema:
     )
 
     other_proflie_schema_view = extend_schema_view(get=other_proflie_get_schema)
-
-
-class UserPostListSchema:
-    user_post_list_get_schema = extend_schema(
-        parameters=[
-            OpenApiParameter(
-                name="subject",
-                type=str,
-                enum=[choice[0] for choice in Post.SUBJECT_TYPE_CHOICES],
-                description="게시글 주제",
-            ),
-        ],
-        summary="유저 게시글 조회",
-        description="특정 사용자의 게시글을 주제별로 조회합니다. (정렬 기준: 최신순)",
-        responses={
-            200: UserPostSerializer(many=True),
-            400: OpenApiResponse(description="Invalid subject parameter"),
-            404: OpenApiResponse(description="Not Found"),
-        },
-        tags=[Profile_Records_Tag],
-    )
-
-    user_post_list_schema_view = extend_schema_view(get=user_post_list_get_schema)
 
 
 class UserNoteSchema:

--- a/repo/profiles/urls.py
+++ b/repo/profiles/urls.py
@@ -16,6 +16,5 @@ urlpatterns = [
     path("<int:id>/", views.OtherProfileAPIView.as_view(), name="other_profile"),
     path("api/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
-    path("<int:id>/posts/", views.UserPostListAPIView.as_view(), name="user_posts"),
     path("<int:id>/notes/", views.UserNoteAPIView.as_view(), name="user_notes"),
 ]

--- a/repo/profiles/views.py
+++ b/repo/profiles/views.py
@@ -25,10 +25,7 @@ from repo.profiles.serializers import (
     UserUpdateSerializer,
 )
 from repo.profiles.services import UserService
-from repo.records.models import Post
-from repo.records.posts.serializers import UserPostSerializer
 from repo.records.serializers import UserNoteSerializer
-from repo.records.services import get_user_posts_by_subject
 
 BASE_BACKEND_URL = settings.BASE_BACKEND_URL
 
@@ -365,21 +362,6 @@ class OtherProfileAPIView(APIView):
 
         serializer = UserProfileSerializer(data)
         return Response(serializer.data, status=status.HTTP_200_OK)
-
-
-@UserPostListSchema.user_post_list_schema_view
-class UserPostListAPIView(APIView):
-    def get(self, request, id):
-        subject = request.query_params.get("subject", "all")
-        valid_subjects = list(dict(Post.SUBJECT_TYPE_CHOICES).keys()) + ["all"]
-
-        if subject not in valid_subjects:
-            return Response({"error": "Invalid subject parameter"}, status=status.HTTP_400_BAD_REQUEST)
-
-        user = get_object_or_404(CustomUser, pk=id)
-        posts = get_user_posts_by_subject(user, subject)
-
-        return get_paginated_response_with_class(request, posts, UserPostSerializer)
 
 
 @UserNoteSchema.user_note_schema_view

--- a/repo/records/posts/schemas.py
+++ b/repo/records/posts/schemas.py
@@ -13,6 +13,7 @@ from repo.records.posts.serializers import (
     PostDetailSerializer,
     PostListSerializer,
     TopPostSerializer,
+    UserPostSerializer,
 )
 
 Post_Tag = "Post"
@@ -111,6 +112,27 @@ class PostSchema:
         patch=post_detail_patch_schema,
         delete=post_detail_delete_schema,
     )
+
+    user_post_list_get_schema = extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="subject",
+                type=str,
+                enum=[choice[0] for choice in Post.SUBJECT_TYPE_CHOICES],
+                description="게시글 주제",
+            ),
+        ],
+        summary="유저 게시글 조회",
+        description="특정 사용자의 게시글을 주제별로 조회합니다. (정렬 기준: 최신순)",
+        responses={
+            200: UserPostSerializer(many=True),
+            400: OpenApiResponse(description="Invalid subject parameter"),
+            404: OpenApiResponse(description="Not Found"),
+        },
+        tags=[Post_Tag],
+    )
+
+    user_post_list_schema_view = extend_schema_view(get=user_post_list_get_schema)
 
     top_posts_get_schema = extend_schema(
         responses={200: TopPostSerializer},

--- a/repo/records/posts/services.py
+++ b/repo/records/posts/services.py
@@ -1,82 +1,242 @@
 from datetime import timedelta
+from itertools import chain
+from typing import Optional
 
-from django.db.models import Count, Exists
+from django.db import transaction
+from django.db.models import BooleanField, Count, Exists, Prefetch, Q, QuerySet, Value
 from django.utils import timezone
 
+from repo.common.view_counter import get_not_viewed_contents
 from repo.interactions.like.services import LikeService
+from repo.interactions.note.services import NoteService
 from repo.interactions.relationship.services import RelationshipService
 from repo.profiles.models import CustomUser
+from repo.records.base import BaseRecordService
 from repo.records.models import Photo, Post, TastedRecord
 
 
-def get_relationship_service():
-    return RelationshipService()
-
-
-def set_post_tasted_records(post: Post, tasted_records: list[TastedRecord]):
-    """게시글에 시음기록 연결"""
-    if tasted_records:
-        post.tasted_records.set(tasted_records)
-
-
-def set_post_photos(post: Post, photos: list[Photo]):
-    """게시글에 사진 연결"""
-    if photos:
-        post.photo_set.set(photos)
-
-
-def create_post(user: CustomUser, validated_data: dict) -> Post:
-    """게시글 생성 및 관련 데이터 설정"""
-    post = Post.objects.create(
-        author=user,
-        title=validated_data["title"],
-        content=validated_data["content"],
-        subject=validated_data["subject"],
-        tag=validated_data.get("tag", None),
-    )
-
-    set_post_tasted_records(post, validated_data.get("tasted_records"))
-    set_post_photos(post, validated_data.get("photos"))
-
-    return post
-
-
-def update_post(post: Post, validated_data: dict) -> Post:
-    """게시글 수정 및 관련 데이터 업데이트"""
-    for attr, value in validated_data.items():
-        if attr not in ["tasted_records", "photos"]:
-            setattr(post, attr, value)
-    post.save()
-
-    set_post_tasted_records(post, validated_data.get("tasted_records"))
-    set_post_photos(post, validated_data.get("photos"))
-
-    return post
-
-
-def get_top_subject_weekly_posts(user, subject):
-    """특정 주제의 게시글 중 일주일 안에 조회수 상위 60개를 가져오는 함수"""
-    time_threshold = timezone.now() - timedelta(days=7)
-    top_posts_base = Post.objects.filter(created_at__gte=time_threshold).annotate(
-        likes=Count("like_cnt", distinct=True),
-        comments=Count("comment", distinct=True),
-    )
-
-    if subject:
-        top_posts_base = top_posts_base.filter(subject=subject)
-    if user is None:
-        return top_posts_base.order_by("-view_cnt")[:60]
-
-    relationship_service = get_relationship_service()
+def get_post_service():
+    relationship_service = RelationshipService()
     like_service = LikeService("post")
-    block_users = relationship_service.get_unique_blocked_user_list(user.id)
+    note_service = NoteService()
+    return PostService(relationship_service, like_service, note_service)
 
-    top_posts = (
-        top_posts_base.exclude(author__in=block_users)
-        .annotate(
-            is_user_liked=Exists(like_service.get_like_subquery_for_post(user)),
+
+class PostService(BaseRecordService):
+    """게시글 관련 비즈니스 로직을 처리하는 서비스"""
+
+    def __init__(self, relationship_service, like_service, note_service):
+        super().__init__(relationship_service, like_service, note_service)
+
+    def get_record_detail(self, pk: int) -> Post:
+        """게시글 상세 조회"""
+        return (
+            Post.objects.filter(pk=pk)
+            .select_related("author")
+            .prefetch_related(
+                Prefetch("tasted_records", queryset=TastedRecord.objects.select_related("bean", "taste_review")),
+                Prefetch("photo_set", queryset=Photo.objects.only("photo_url")),
+            )
+            .first()
         )
-        .order_by("-view_cnt")[:60]
-    )
 
-    return top_posts
+    def get_user_records(self, user_id, **kwargs):
+        """유저가 작성한 게시글 조회"""
+        subject = kwargs.get("subject", None)
+        user = CustomUser.objects.get(id=user_id)
+
+        subject_filter = Q(subject=subject) if subject else Q()
+        posts = (
+            user.post_set.filter(subject_filter)
+            .select_related("author")
+            .prefetch_related("tasted_records", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
+            .order_by("-id")
+        )
+        return posts
+
+    def get_record_list(self, user: CustomUser, **kwargs) -> QuerySet[Post]:
+        """홈 게시글 리스트 조회"""
+        subject = kwargs.get("subject", None)
+        request = kwargs.get("request", None)
+
+        following_users = self.relationship_service.get_following_user_list(user.id)
+
+        add_filter = {"author__in": following_users}
+        following_posts = self.get_feed_queryset(user, add_filter, None, subject)
+        unfollowing_posts = self.get_unfollowing_feed(user)
+
+        posts = list(chain(following_posts, unfollowing_posts))
+
+        if request:
+            posts = get_not_viewed_contents(request, posts, "post_viewed")
+
+        return posts
+
+    @transaction.atomic
+    def create_record(self, user: CustomUser, validated_data: dict) -> Post:
+        """게시글 생성"""
+        post = Post.objects.create(
+            author=user,
+            title=validated_data["title"],
+            content=validated_data["content"],
+            subject=validated_data["subject"],
+            tag=validated_data.get("tag", None),
+        )
+        self._set_post_relations(post, validated_data)
+        return post
+
+    @transaction.atomic
+    def update_record(self, post: Post, validated_data: dict) -> Post:
+        """게시글 수정 및 관련 데이터 업데이트"""
+
+        for attr, value in validated_data.items():
+            if attr not in ["tasted_records", "photos"]:
+                setattr(post, attr, value)
+
+        self._set_post_relations(post, validated_data)
+
+        post.save()
+        return post
+
+    def delete_record(self, post: Post):
+        """게시글 삭제"""
+        post.delete()
+
+    def get_top_subject_weekly_posts(self, user: Optional[CustomUser], subject: str) -> QuerySet[Post]:
+        """특정 주제의 게시글 중 일주일 안에 조회수 상위 60개를 가져오는 함수"""
+        top_posts_base = self._get_base_weekly_posts()
+
+        if subject:
+            top_posts_base = top_posts_base.filter(subject=subject)
+
+        if user is None:
+            return self._get_anonymous_top_posts(top_posts_base)
+
+        return self._get_authenticated_top_posts(user, top_posts_base)
+
+    def _get_base_weekly_posts(self) -> QuerySet[Post]:
+        """일주일 이내의 기본 게시글 쿼리셋을 반환"""
+        time_threshold = timezone.now() - timedelta(days=7)
+        print(
+            Post.objects.filter(created_at__gte=time_threshold).annotate(
+                likes=Count("like_cnt", distinct=True),
+                comments=Count("comment", distinct=True),
+            )
+        )
+        return Post.objects.filter(created_at__gte=time_threshold).annotate(
+            likes=Count("like_cnt", distinct=True),
+            comments=Count("comment", distinct=True),
+        )
+
+    def _get_anonymous_top_posts(self, queryset: QuerySet[Post]) -> QuerySet[Post]:
+        """비로그인 사용자를 위한 상위 게시글 반환"""
+        return queryset.order_by("-view_cnt")[:60]
+
+    def _get_authenticated_top_posts(self, user: CustomUser, queryset: QuerySet[Post]) -> QuerySet[Post]:
+        """로그인 사용자를 위한 상위 게시글 반환"""
+        block_users = self.relationship_service.get_unique_blocked_user_list(user.id)
+
+        return (
+            queryset.exclude(author__in=block_users)
+            .annotate(
+                is_user_liked=Exists(self.like_service.get_like_subquery_for_post(user)),
+            )
+            .order_by("-view_cnt")[:60]
+        )
+
+    def _set_post_relations(self, post: Post, data: dict):
+        """게시글 관계 데이터 설정"""
+        if tasted_records := data.get("tasted_records"):
+            post.tasted_records.set(tasted_records)
+        if photos := data.get("photos"):
+            post.photo_set.set(photos)
+
+    ## 피드 조회 관련 메서드
+
+    def get_base_record_list_queryset(self, user: Optional[CustomUser] = None):
+        """공통적으로 사용하는 기본 쿼리셋 생성"""
+        base_queryset = (
+            Post.objects.select_related("author")
+            .prefetch_related("tasted_records", "comment_set", "note_set", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
+            .annotate(
+                likes=Count("like_cnt", distinct=True),
+                comments=Count("comment", distinct=True),
+            )
+        )
+        if user:
+            base_queryset = base_queryset.annotate(
+                is_user_liked=Exists(self.like_service.get_like_subquery_for_post(user)),
+                is_user_noted=Exists(self.note_service.get_note_subquery_for_post(user)),
+            )
+        return base_queryset
+
+    def get_feed_queryset(self, user, add_filter=None, exclude_filter=None, subject=None):
+        """
+        게시글 피드를 위한 필터링된 쿼리셋 생성
+
+        Args:
+            user: 사용자 객체
+            add_filter: 추가할 필터 조건 (dict)
+            exclude_filter: 제외할 필터 조건 (dict)
+            subject: 게시글 주제
+
+        Returns:
+            QuerySet: 필터링된 게시글 쿼리셋
+        """
+
+        base_queryset = self.get_base_record_list_queryset(user)
+
+        filters = Q(**add_filter) if add_filter else Q()
+        excludes = Q(**exclude_filter) if exclude_filter else Q()
+
+        if user:  # 기본적으로 차단한 사용자는 제외
+            block_users = self.relationship_service.get_unique_blocked_user_list(user.id)
+            filters &= ~Q(author__in=block_users)
+
+        if subject:
+            filters &= Q(subject=subject)
+
+        return base_queryset.filter(filters).exclude(excludes)
+
+    def get_following_feed(self, user: CustomUser) -> QuerySet[Post]:
+        following_users = self.relationship_service.get_following_user_list(user.id)
+
+        add_filter = {"author__in": following_users}
+
+        return self.get_feed_queryset(user, add_filter, None, None)
+
+    # home following feed
+    def get_following_feed_and_gte_one_hour(self, user: CustomUser) -> QuerySet[Post]:
+        one_hour_ago = timezone.now() - timedelta(hours=1)
+        add_filter = {"created_at__gte": one_hour_ago}
+
+        following_feed = self.get_following_feed(user)
+
+        return following_feed.filter(add_filter)
+
+    # home common feed
+    def get_unfollowing_feed(self, user: CustomUser) -> QuerySet[Post]:
+        following_users = self.relationship_service.get_following_user_list(user.id)
+
+        exclude_filter = {"author__in": following_users}
+
+        return self.get_feed_queryset(user, None, exclude_filter, None)
+
+    # home refresh feed
+    def get_refresh_feed(self, user: CustomUser) -> QuerySet[Post]:
+        return self.get_feed_queryset(user, None, None, None)
+
+    # 비로그인 사용자를 위한 게시글 피드
+    def get_record_list_for_anonymous(self) -> QuerySet[Post]:
+        """비로그인 사용자 게시글 피드 조회"""
+        return (
+            Post.objects.select_related("author")
+            .prefetch_related("tasted_records", "comment_set", "note_set", Prefetch("photo_set", queryset=Photo.objects.only("photo_url")))
+            .annotate(
+                likes=Count("like_cnt", distinct=True),
+                comments=Count("comment", distinct=True),
+                is_user_liked=Value(False, output_field=BooleanField()),  # False 고정
+                is_user_noted=Value(False, output_field=BooleanField()),  # False 고정
+            )
+            .order_by("?")
+        )

--- a/repo/records/posts/services.py
+++ b/repo/records/posts/services.py
@@ -40,12 +40,13 @@ class PostService(BaseRecordService):
             .first()
         )
 
-    def get_user_records(self, user_id, **kwargs):
+    def get_user_records(self, user_id, **kwargs) -> QuerySet[Post]:
         """유저가 작성한 게시글 조회"""
-        subject = kwargs.get("subject", None)
         user = CustomUser.objects.get(id=user_id)
+        subject = kwargs.get("subject", None)
 
-        subject_filter = Q(subject=subject) if subject else Q()
+        subject_filter = Q(subject=subject) if subject != "all" else Q()
+
         posts = (
             user.post_set.filter(subject_filter)
             .select_related("author")

--- a/repo/records/posts/urls.py
+++ b/repo/records/posts/urls.py
@@ -5,5 +5,6 @@ from repo.records.posts import views
 urlpatterns = [
     path("", views.PostListCreateAPIView.as_view(), name="post-list-create"),
     path("<int:pk>/", views.PostDetailAPIView.as_view(), name="post-detail"),
+    path("user/<int:id>/", views.UserPostListAPIView.as_view(), name="user-post-list"),
     path("top/", views.TopSubjectPostsAPIView.as_view(), name="post-top"),
 ]

--- a/repo/records/posts/views.py
+++ b/repo/records/posts/views.py
@@ -1,4 +1,3 @@
-from django.db import transaction
 from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticatedOrReadOnly
@@ -11,11 +10,6 @@ from repo.common.view_counter import update_view_count
 from repo.records.posts.schemas import PostSchema
 from repo.records.posts.serializers import *
 from repo.records.posts.services import *
-from repo.records.services import (
-    get_annonymous_posts_feed,
-    get_post_detail,
-    get_post_feed,
-)
 
 
 @PostSchema.post_list_create_schema_view
@@ -24,31 +18,26 @@ class PostListCreateAPIView(APIView):
 
     permission_classes = [IsAuthenticatedOrReadOnly]
 
+    def __init__(self, **kwargs):
+        self.post_service = get_post_service()
+
     def get(self, request):
         user = request.user
         if not user.is_authenticated:
-            posts = get_annonymous_posts_feed()
+            posts = self.post_service.get_record_list_for_anonymous()
             return get_paginated_response_with_class(request, posts, PostListSerializer)
 
         subject = request.query_params.get("subject", None)
-        posts = get_post_feed(request, user, subject)
-
+        posts = self.post_service.get_record_list(user, subject=subject, request=request)
         return get_paginated_response_with_class(request, posts, PostListSerializer)
 
     def post(self, request):
         serializer = PostCreateUpdateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        try:
-            with transaction.atomic():
-                post = create_post(request.user, serializer.validated_data)
-                serializer = PostDetailSerializer(post, context={"request": request})
-
-            return Response(serializer.data, status=status.HTTP_201_CREATED)
-        except PermissionError as e:
-            return Response({"error": str(e)}, status=status.HTTP_403_FORBIDDEN)
-        except Exception as e:
-            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        post = self.post_service.create_record(request.user, serializer.validated_data)
+        serializer = PostDetailSerializer(post, context={"request": request})
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 @PostSchema.post_detail_schema_view
@@ -63,6 +52,9 @@ class PostDetailAPIView(APIView):
 
     permission_classes = [IsOwnerOrReadOnly]
 
+    def __init__(self, **kwargs):
+        self.post_service = get_post_service()
+
     def get_object(self, pk):
         post = get_object_or_404(Post, pk=pk)
         self.check_object_permissions(self.request, post)
@@ -70,7 +62,7 @@ class PostDetailAPIView(APIView):
 
     def get(self, request, pk):
         post = self.get_object(pk)
-        post_detail = get_post_detail(post.id)
+        post_detail = self.post_service.get_record_detail(post.id)
 
         # 쿠키 기반 조회수 업데이트
         response = update_view_count(request, post_detail, Response(), "post_viewed")
@@ -84,22 +76,20 @@ class PostDetailAPIView(APIView):
         serializer = PostCreateUpdateSerializer(post, data=request.data, partial=False)
         serializer.is_valid(raise_exception=True)
 
-        with transaction.atomic():
-            updated_post = update_post(post, serializer.validated_data)
-            return Response(PostDetailSerializer(updated_post, context={"request": request}).data, status=status.HTTP_200_OK)
+        updated_post = self.post_service.update_record(post, serializer.validated_data)
+        return Response(PostDetailSerializer(updated_post, context={"request": request}).data, status=status.HTTP_200_OK)
 
     def patch(self, request, pk):
         post = self.get_object(pk)
         serializer = PostCreateUpdateSerializer(post, data=request.data, partial=True)
         serializer.is_valid(raise_exception=True)
 
-        with transaction.atomic():
-            updated_post = update_post(post, serializer.validated_data)
-            return Response(PostDetailSerializer(updated_post, context={"request": request}).data, status=status.HTTP_200_OK)
+        updated_post = self.post_service.update_record(post, serializer.validated_data)
+        return Response(PostDetailSerializer(updated_post, context={"request": request}).data, status=status.HTTP_200_OK)
 
     def delete(self, request, pk):
         post = self.get_object(pk)
-        post.delete()
+        self.post_service.delete_record(post)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -118,9 +108,12 @@ class TopSubjectPostsAPIView(APIView):
 
     permission_classes = [AllowAny]
 
+    def __init__(self, **kwargs):
+        self.post_service = get_post_service()
+
     def get(self, request):
         user = request.user  # 비회원 = None
         subject = request.query_params.get("subject")  # 주제 필터 없는 경우 = None
 
-        posts = get_top_subject_weekly_posts(user, subject)
+        posts = self.post_service.get_top_subject_weekly_posts(user, subject)
         return get_paginated_response_with_class(request, posts, TopPostSerializer)

--- a/repo/records/posts/views.py
+++ b/repo/records/posts/views.py
@@ -93,6 +93,26 @@ class PostDetailAPIView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
+@PostSchema.user_post_list_schema_view
+class UserPostListAPIView(APIView):
+    """특정 사용자의 게시글 조회 API"""
+
+    def __init__(self, **kwargs):
+        self.post_service = get_post_service()
+
+    def get(self, request, id):
+        subject = request.query_params.get("subject", "all")
+        valid_subjects = list(dict(Post.SUBJECT_TYPE_CHOICES).keys()) + ["all"]
+
+        if subject not in valid_subjects:
+            return Response({"error": "Invalid subject parameter"}, status=status.HTTP_400_BAD_REQUEST)
+
+        user = get_object_or_404(CustomUser, pk=id)
+        posts = self.post_service.get_user_records(user.id, subject=subject)
+
+        return get_paginated_response_with_class(request, posts, UserPostSerializer)
+
+
 @PostSchema.top_posts_schema_view
 class TopSubjectPostsAPIView(APIView):
     """


### PR DESCRIPTION
## #️⃣연관된 이슈

> #92 #104

## 📝작업 내용

1. **기능 리팩토링 및 이동**:
   - `repo/profiles/schemas.py`: `UserPostListSchema` 클래스 삭제.
   - `repo/profiles/urls.py`: 사용자 게시글 관련 URL 패턴 삭제.
   - `repo/profiles/views.py`: `UserPostListAPIView` 클래스 및 메소드 삭제.

2. **`repo/records/posts`에 기능 추가**:
   - `repo/records/posts/schemas.py`: 사용자 게시글 목록을 위한 새로운 스키마 추가.
   - `repo/records/posts/urls.py`: 사용자 게시글 목록을 위한 URL 패턴 추가.
   - `repo/records/posts/views.py`: `UserPostListAPIView` 클래스 및 메소드 추가.

3. **서비스 레이어 개선**:
   - `repo/records/posts/services.py`: `PostService` 클래스를 도입하여 게시글 생성, 수정, 삭제 및 사용자 게시글과 인기 게시글을 처리하는 비즈니스 로직 추가.

전체적으로, 게시글 목록 기능이 `repo/profiles`에서 `repo/records/posts`로 이동하고, 서비스 레이어에서 비즈니스 로직을 통합한 구조로 개선되었습니다.