### PR TITLE
Feed 리펙토링

### DIFF
--- a/repo/records/base.py
+++ b/repo/records/base.py
@@ -45,8 +45,9 @@ class BaseRecordService(ABC):
         """게시물 삭제"""
         pass
 
+    @staticmethod
     @abstractmethod
-    def get_base_record_list_queryset(self, user: Optional[CustomUser] = None) -> QuerySet[Post | TastedRecord]:
+    def get_base_record_list_queryset() -> QuerySet[Post | TastedRecord]:
         """공통적으로 사용하는 기본 게시물 리스트 쿼리셋 생성"""
         pass
 
@@ -58,7 +59,7 @@ class BaseRecordService(ABC):
         pass
 
     @abstractmethod
-    def get_following_feed(self, user: CustomUser, following_users: QuerySet[CustomUser]) -> QuerySet[Post | TastedRecord]:
+    def get_feed_by_follow_relation(self, user: CustomUser, follow: bool) -> QuerySet[Post | TastedRecord]:
         """팔로잉 피드 조회"""
         pass
 

--- a/repo/records/posts/views.py
+++ b/repo/records/posts/views.py
@@ -129,11 +129,11 @@ class TopSubjectPostsAPIView(APIView):
     permission_classes = [AllowAny]
 
     def __init__(self, **kwargs):
-        self.post_service = get_post_service()
+        self.top_post_service = get_top_post_service()
 
     def get(self, request):
         user = request.user  # 비회원 = None
         subject = request.query_params.get("subject")  # 주제 필터 없는 경우 = None
 
-        posts = self.post_service.get_top_subject_weekly_posts(user, subject)
+        posts = self.top_post_service.get_top_subject_weekly_posts(user, subject)
         return get_paginated_response_with_class(request, posts, TopPostSerializer)

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -72,8 +72,8 @@ class FeedService:
         """
 
         # 1. 팔로우하지 않고 차단하지 않은 유저들의 시음기록, 게시글
-        common_tasted_records = self.tasted_record_service.get_unfollowing_feed(user)
-        common_posts = self.post_service.get_unfollowing_feed(user)
+        common_tasted_records = self.tasted_record_service.get_feed_by_follow_relation(user, False)
+        common_posts = self.post_service.get_feed_by_follow_relation(user, False)
 
         # 2. 조회하지 않은 시음기록, 게시글
         not_viewd_tasted_records = get_not_viewed_contents(request, common_tasted_records, "tasted_record_viewed")


### PR DESCRIPTION
## #️⃣연관된 이슈

> 

## 📝작업 내용
이 풀 리퀘스트에는 쿼리 및 필터링 메커니즘 개선에 중점을 둔 피드 및 기록 서비스에 대한 중요한 변경 사항이 포함되어 있습니다. 가장 중요한 변경 사항은 피드 데이터 가져오기 메서드 리팩터링, 유형 주석 추가, 인기 게시물에 대한 새로운 서비스 생성 등입니다.

리팩터링 및 개선 사항

* [`repo/records/base.py`](diffhunk://#diff-be011f7d61fbdc9f3b41f8638f75e4a20d95a8745772b83eb0f45911d396b9b8R48-R50): 피드 검색 로직을 개선하기 위해 `get_feed_queryset` 및 `get_feed_by_follow_relation` 메서드를 리팩터링하고 명확성을 위해 메서드 이름을 변경했습니다. 
* [`repo/records/posts/services.py`](diffhunk://#diff-13790172832a4a58a15036243d8233a2f8d8758d121775eee0dda6f539d2905cR25-R30): 인기 게시물 처리를 위한 `TopPostService`를 도입하고, `get_user_records` 및 `get_record_list`를 리팩터링하고, 중복 메서드를 제거했습니다. 
* [`repo/records/posts/views.py`](diffhunk://#diff-ca1d6159b51300ee744e4da4410fde4c17d23a95364c44a555e86527034fd9f2L132-R138): 새로운 `TopPostService`를 사용하도록 `TopSubjectPostsAPIView`를 업데이트했습니다.
* [`repo/records/services.py`](diffhunk://#diff-c550a5b2e807ce2f0ca0600fa713562038c60610dbc1b64a9958b9894bfeedf6L75-R76): 새로운 `get_common_feed` 메서드를 사용하도록 `get_feed_by_follow_relation`을 리팩터링했습니다.

유형 어노테이션 및 정적 메서드:

* [`repo/records/tasted_record/services.py`](diffhunk://#diff-49a4034a3494295c879c7af2527badfd0d25ee87564be611138da1ee18430155L3-R3): 메서드에 타입 어노테이션을 추가하고 `get_base_record_list_queryset`을 정적 메서드로 변환했습니다. 