### PR TITLE
비회원 피드 조회 캐싱

### DIFF
--- a/repo/records/posts/views.py
+++ b/repo/records/posts/views.py
@@ -24,11 +24,14 @@ class PostListCreateAPIView(APIView):
 
     def get(self, request):
         user = request.user
-        if not user.is_authenticated:
-            posts = self.post_service.get_record_list_for_anonymous()
-            return get_paginated_response_with_class(request, posts, PostListSerializer)
-
         subject = request.query_params.get("subject", None)
+
+        if not user.is_authenticated:
+            posts = self.post_service.get_record_list_for_anonymous(subject)
+            paginator = PageNumberPagination()
+            paginated_posts = paginator.paginate_queryset(posts, request)
+            return paginator.get_paginated_response(paginated_posts)
+
         posts = self.post_service.get_record_list(user, subject=subject, request=request)
         return get_paginated_response_with_class(request, posts, PostListSerializer)
 

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -5,7 +5,6 @@ from django.core.cache import cache
 
 from repo.common.view_counter import get_not_viewed_contents
 from repo.records.posts.services import PostService, get_post_service
-from repo.records.serializers import FeedSerializer
 from repo.records.tasted_record.services import (
     TastedRecordService,
     get_tasted_record_service,
@@ -122,28 +121,15 @@ class FeedService:
         Returns:
             list: 시음기록과 게시글이 랜덤으로 정렬된 피드 리스트
         """
-        tasted_records = self.tasted_record_service.get_record_list_for_anonymous()
-        posts = self.post_service.get_record_list_for_anonymous()
-
-        combined_data = list(chain(tasted_records, posts))
-        random.shuffle(combined_data)
-
-        return combined_data
-
-    def get_anonymous_cache_feed(self):
-        """
-        비로그인 사용자를 위한 캐시 피드를 반환합니다.
-
-        - 공개 시음기록과 게시글 포함
-        - 랜덤 순서로 정렬
-        """
         cache_key = "anonymous_feed"
-        feed_data = cache.get(cache_key)
+        feeds = cache.get(cache_key)
 
-        if feed_data is None:
-            feed_data = FeedSerializer(self.get_anonymous_feed(), many=True).data
-            cache.set(cache_key, feed_data, timeout=60 * 5)
-        else:
-            random.shuffle(feed_data)
+        if feeds is None:
+            tasted_records = self.tasted_record_service.get_record_list_for_anonymous()
+            posts = self.post_service.get_record_list_for_anonymous()
 
-        return feed_data
+            feeds = list(chain(tasted_records, posts))
+            cache.set(cache_key, feeds, timeout=60 * 5)
+
+        random.shuffle(feeds)
+        return feeds

--- a/repo/records/services.py
+++ b/repo/records/services.py
@@ -1,8 +1,11 @@
 import random
 from itertools import chain
 
+from django.core.cache import cache
+
 from repo.common.view_counter import get_not_viewed_contents
 from repo.records.posts.services import PostService, get_post_service
+from repo.records.serializers import FeedSerializer
 from repo.records.tasted_record.services import (
     TastedRecordService,
     get_tasted_record_service,
@@ -126,3 +129,21 @@ class FeedService:
         random.shuffle(combined_data)
 
         return combined_data
+
+    def get_anonymous_cache_feed(self):
+        """
+        비로그인 사용자를 위한 캐시 피드를 반환합니다.
+
+        - 공개 시음기록과 게시글 포함
+        - 랜덤 순서로 정렬
+        """
+        cache_key = "anonymous_feed"
+        feed_data = cache.get(cache_key)
+
+        if feed_data is None:
+            feed_data = FeedSerializer(self.get_anonymous_feed(), many=True).data
+            cache.set(cache_key, feed_data, timeout=60 * 5)
+        else:
+            random.shuffle(feed_data)
+
+        return feed_data

--- a/repo/records/tasted_record/views.py
+++ b/repo/records/tasted_record/views.py
@@ -1,6 +1,7 @@
 from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
 from rest_framework import generics, status
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -48,9 +49,12 @@ class TastedRecordListCreateAPIView(APIView):
     def get(self, request):
         serializer_class = TastedRecordListSerializer
         user = request.user
+
         if not user.is_authenticated:
             tasted_records = self.tasted_record_service.get_record_list_for_anonymous()
-            return get_paginated_response_with_class(request, tasted_records, serializer_class)
+            paginator = PageNumberPagination()
+            paginated_tasted_records = paginator.paginate_queryset(tasted_records, request)
+            return paginator.get_paginated_response(paginated_tasted_records)
 
         tasted_records = self.tasted_record_service.get_record_list(user, request=request)
         return get_paginated_response_with_class(request, tasted_records, serializer_class)

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -38,7 +38,7 @@ class FeedAPIView(APIView):
         user = request.user
         serializer_class = FeedSerializer
         if not request.user.is_authenticated:  # 비회원
-            feed_data = self.feed_service.get_anonymous_cache_feed()
+            feed_data = self.feed_service.get_anonymous_feed()
             paginator = PageNumberPagination()
             paginated_queryset = paginator.paginate_queryset(feed_data, request)
             return paginator.get_paginated_response(paginated_queryset)

--- a/repo/records/views.py
+++ b/repo/records/views.py
@@ -1,4 +1,3 @@
-from django.core.cache import cache
 from django.db import transaction
 from django.http import Http404
 from rest_framework import status
@@ -38,14 +37,8 @@ class FeedAPIView(APIView):
     def get(self, request):
         user = request.user
         serializer_class = FeedSerializer
-        if not request.user.is_authenticated:  # AnonymousUser
-            cache_key = "anonymous_feed"
-            feed_data = cache.get(cache_key)
-
-            if feed_data is None:
-                feed_data = FeedSerializer(self.feed_service.get_anonymous_feed(), many=True).data
-                cache.set(cache_key, feed_data, timeout=60 * 60 * 3)
-
+        if not request.user.is_authenticated:  # 비회원
+            feed_data = self.feed_service.get_anonymous_cache_feed()
             paginator = PageNumberPagination()
             paginated_queryset = paginator.paginate_queryset(feed_data, request)
             return paginator.get_paginated_response(paginated_queryset)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #146 

## 📝작업 내용
> 비회원 사용자 전용 게시글, 시음기록, 전체 피드 캐싱

### 캐싱 개선 
- 비회원 사용자 게시글, 시음 기록 피드 캐싱 적용.
- 캐싱한 게시글, 시음기록 재사용한 전체 피드 리스트 캐싱 적용
- 데이터베이스 부하 감소 및 성능 개선

### 코드 정리 및 import 추가
- `PostListSerializer` 및 `TastedRecordListSerializer` 추가로 데이터 직렬화 지원.

비회원 사용자의 피드 조회 응답속도 개선 및 DB 부하 감소 