### PR TITLE
Faet 대댓글 좋아요여부 추가

### DIFF
--- a/repo/records/comment/services.py
+++ b/repo/records/comment/services.py
@@ -128,3 +128,23 @@ class CommentService:
             return [user_recent_comment_obj] + parent_comments
 
         return parent_comments
+
+    def get_comment_list_for_annonymouse(self) -> list[Comment]:
+        """익명 유저 댓글 목록 조회"""
+        all_comments = self.target_object.comment_set.select_related("author", "parent").order_by("id").all()
+
+        parent_comments = []
+        replies_map = defaultdict(list)
+
+        for comment in all_comments:
+            comment.is_user_liked = False
+
+            if comment.parent_id:
+                replies_map[comment.parent_id].append(comment)
+            else:
+                parent_comments.append(comment)
+
+        for parent in parent_comments:
+            parent.replies_list = replies_map[parent.id]
+
+        return parent_comments

--- a/repo/records/comment/services.py
+++ b/repo/records/comment/services.py
@@ -70,8 +70,9 @@ class CommentService:
 
     def get_comment_list(self, user: CustomUser) -> QuerySet[Comment]:
         """댓글 목록 조회"""
-        block_users = self.relationship_service.get_unique_blocked_user_list(user.id)
         target_object_comments = self.target_object.comment_set
+
+        block_users = list(self.relationship_service.get_unique_blocked_user_list(user.id))
         user_liked_comments = set(target_object_comments.filter(like_cnt=user.id).values_list("id", flat=True))
 
         base_queryset = (

--- a/repo/records/comment/services.py
+++ b/repo/records/comment/services.py
@@ -68,6 +68,24 @@ class CommentService:
         else:
             comment.delete()
 
+    def create_comment(self, user: CustomUser, validated_data: dict) -> Comment:
+        """댓글 생성"""
+        if self.target_object is None:
+            raise NotFoundException(detail="Target object not found", code="not_found")
+
+        comment_data = {
+            "author": user,
+            "content": validated_data.get("content"),
+            "parent": validated_data.get("parent", None),
+        }
+
+        if isinstance(self.target_object, Post):
+            comment_data["post"] = self.target_object
+        elif isinstance(self.target_object, TastedRecord):
+            comment_data["tasted_record"] = self.target_object
+
+        return Comment.objects.create(**comment_data)
+
     def get_comment_list(self, user: CustomUser) -> list[Comment]:
         """댓글 목록 조회 (유저 최신 댓글 우선 정렬)"""
         blocked_users = set(self.relationship_service.get_unique_blocked_user_list(user.id))
@@ -110,21 +128,3 @@ class CommentService:
             return [user_recent_comment_obj] + parent_comments
 
         return parent_comments
-
-    def create_comment(self, user: CustomUser, validated_data: dict) -> Comment:
-        """댓글 생성"""
-        if self.target_object is None:
-            raise NotFoundException(detail="Target object not found", code="not_found")
-
-        comment_data = {
-            "author": user,
-            "content": validated_data.get("content"),
-            "parent": validated_data.get("parent", None),
-        }
-
-        if isinstance(self.target_object, Post):
-            comment_data["post"] = self.target_object
-        elif isinstance(self.target_object, TastedRecord):
-            comment_data["tasted_record"] = self.target_object
-
-        return Comment.objects.create(**comment_data)

--- a/repo/records/comment/services.py
+++ b/repo/records/comment/services.py
@@ -86,13 +86,12 @@ class CommentService:
             .order_by("id")
         )
 
-        user_latest_comment = base_queryset.filter(author=user).order_by("-id").first()
+        user_comments = list(base_queryset.filter(author=user).order_by("-id")[:1])
+        user_latest_comment_id = user_comments[0].id if user_comments else None
 
-        comments = list(base_queryset.exclude(id=user_latest_comment.id if user_latest_comment else None).order_by("id"))
+        other_comments = list(base_queryset.exclude(id=user_latest_comment_id).order_by("id"))
 
-        # 사용자의 최신 댓글 맨 앞에 추가
-        if user_latest_comment:
-            comments = [user_latest_comment] + comments
+        comments = user_comments + other_comments
 
         for comment in comments:
             comment.replies_list = list(comment.replies.all())

--- a/repo/records/comment/views.py
+++ b/repo/records/comment/views.py
@@ -27,7 +27,10 @@ class CommentApiView(APIView):
 
     def get(self, request, object_type, object_id):
         comment_service = CommentService(object_type, object_id)
-        comments = comment_service.get_comment_list(request.user)
+        if not request.user.is_authenticated:
+            comments = comment_service.get_comment_list_for_annonymouse()
+        else:
+            comments = comment_service.get_comment_list(request.user)
 
         return get_paginated_response_with_class(request, comments, CommentOutputSerializer)
 


### PR DESCRIPTION
## #️⃣연관된 이슈

## 📝작업 내용

> 대댓글 좋아요 여부 추가 및 코드 리펙토링 

- 대댓글 좋아요 여부 추가 
- 비회원 댓글 리스트 조회 로직 추가 
- 코드 최적화 및 정리 (복잡한 로직을 단계별로 분리)
  - select_related N+1 문제 방지
  - set 자료구조 활용으로 사용자 좋아요 여부 판단 로직 수정
  - 차단된 사용자 제외
  - 댓글과 대댓글 분류 및 사용자의 좋아요 여부 상태 설정 
  - 사용자의 최신 부모 댓글 우선 정렬