### PR TITLE
Fix 원두, 취향리포트 통계 로직 수정

### DIFF
--- a/repo/beans/services.py
+++ b/repo/beans/services.py
@@ -96,18 +96,13 @@ class BeanService:
             total_flavor_count = flavor_counter.total()
 
         top_flavors = []
-        total_percent = 0
-
         for flavor, count in flavor_items:
             percent = round((count / total_flavor_count) * 100)
             top_flavors.append({"flavor": flavor, "percentage": percent})
-            total_percent += percent
 
-        if top_flavors and total_percent != 100:
+        total_percent = sum(flavor["percentage"] for flavor in top_flavors)
+        if total_percent != 100:
             diff = 100 - total_percent
-            top_flavors[-1]["percentage"] += diff
-
-        if top_flavors[-1]["percentage"] <= 0:
-            top_flavors.pop()
+            top_flavors[0]["percentage"] += diff
 
         return top_flavors

--- a/repo/beans/services.py
+++ b/repo/beans/services.py
@@ -80,7 +80,7 @@ class BeanService:
             return self.create(bean_data)
 
     @staticmethod
-    def get_flavor_percentages(flavors: list[str]) -> list[dict[str, str | int]]:
+    def get_flavor_percentages(flavors: list[str], limit: int = None) -> list[dict[str, str | int]]:
         split_flavors = []
         for flavor_str in flavors:
             if flavor_str:
@@ -88,8 +88,12 @@ class BeanService:
                 split_flavors.extend(fs)  # 쉼표 기준 맛 분리
 
         flavor_counter = Counter(split_flavors)
-        total_flavor_count = flavor_counter.total()
-        flavor_items = sorted(flavor_counter.items(), key=lambda x: x[1], reverse=True)
+        flavor_items = flavor_counter.most_common(limit)
+
+        if limit:
+            total_flavor_count = sum(count for _, count in flavor_items)
+        else:
+            total_flavor_count = flavor_counter.total()
 
         top_flavors = []
         total_percent = 0

--- a/repo/beans/services.py
+++ b/repo/beans/services.py
@@ -84,8 +84,8 @@ class BeanService:
         split_flavors = []
         for flavor_str in flavors:
             if flavor_str:
-                a = [i.strip() for i in flavor_str.split(",")]
-                split_flavors.extend(a)  # 쉼표 기준 맛 분리
+                fs = [i.strip() for i in flavor_str.split(",")]
+                split_flavors.extend(fs)  # 쉼표 기준 맛 분리
 
         flavor_counter = Counter(split_flavors)
         total_flavor_count = flavor_counter.total()

--- a/repo/beans/services.py
+++ b/repo/beans/services.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import Dict
 
 from django.db.models import Avg, Count, FloatField, QuerySet
@@ -77,3 +78,32 @@ class BeanService:
             return Bean.objects.get(**bean_data)
         else:
             return self.create(bean_data)
+
+    @staticmethod
+    def get_flavor_percentages(flavors: list[str]) -> list[dict[str, str | int]]:
+        split_flavors = []
+        for flavor_str in flavors:
+            if flavor_str:
+                a = [i.strip() for i in flavor_str.split(",")]
+                split_flavors.extend(a)  # 쉼표 기준 맛 분리
+
+        flavor_counter = Counter(split_flavors)
+        total_flavor_count = flavor_counter.total()
+        flavor_items = sorted(flavor_counter.items(), key=lambda x: x[1], reverse=True)
+
+        top_flavors = []
+        total_percent = 0
+
+        for flavor, count in flavor_items:
+            percent = round((count / total_flavor_count) * 100)
+            top_flavors.append({"flavor": flavor, "percentage": percent})
+            total_percent += percent
+
+        if top_flavors and total_percent != 100:
+            diff = 100 - total_percent
+            top_flavors[-1]["percentage"] += diff
+
+        if top_flavors[-1]["percentage"] <= 0:
+            top_flavors.pop()
+
+        return top_flavors

--- a/repo/beans/views.py
+++ b/repo/beans/views.py
@@ -98,10 +98,15 @@ class BeanDetailView(APIView):
         flavor_counter = Counter(split_flavors)
         total_flavor_count = sum(flavor_counter.values())
 
-        top_flavors = [
-            {"flavor": flavor, "percentage": int(round((count / total_flavor_count) * 100, 0))}
-            for flavor, count in flavor_counter.most_common(4)
-        ]
+        flavor_counter = Counter(split_flavors)
+        total_flavor_count = flavor_counter.total()
+        flavor_items = flavor_counter.items()
+
+        top_flavors = []
+        for flavor, count in flavor_items:
+            top_flavors.append({"flavor": flavor, "percentage": int(round((count / total_flavor_count) * 100, 0))})
+
+        top_flavors.sort(key=lambda x: x["percentage"], reverse=True)
 
         return top_flavors
 

--- a/repo/beans/views.py
+++ b/repo/beans/views.py
@@ -1,5 +1,4 @@
 from collections import Counter
-from itertools import chain
 
 from django.db.models import Avg, Count
 from django.shortcuts import get_object_or_404
@@ -90,7 +89,12 @@ class BeanDetailView(APIView):
 
     def get_top_flavors(self, records: TastedRecord) -> list[dict]:
         flavors = records.values_list("taste_review__flavor", flat=True)
-        split_flavors = chain.from_iterable(flavor.split(", ") for flavor in flavors if flavor)
+
+        split_flavors = []
+        for flavor_str in flavors:
+            if flavor_str:
+                split_flavors.extend(flavor_str.split(","))  # 쉼표 기준 맛 분리
+
         flavor_counter = Counter(split_flavors)
         total_flavor_count = sum(flavor_counter.values())
 

--- a/repo/profiles/views.py
+++ b/repo/profiles/views.py
@@ -646,6 +646,9 @@ class PrefCountryAPIView(APIView):
             percent = round((count / total_origin_count) * 100, 2)
             top_origins.append({"origin": origin, "percentage": percent})
 
+        total_percent = sum(origin["percentage"] for origin in top_origins)
+        if total_percent != 100:
+            diff = 100 - total_percent
             top_origins[0]["percentage"] += round(diff, 2)
 
         serializer = PrefCountrySerializer(data={"top_origins": top_origins})

--- a/repo/profiles/views.py
+++ b/repo/profiles/views.py
@@ -352,36 +352,6 @@ class SignupView(APIView):
         return Response({"message": "회원가입을 성공했습니다."}, status=status.HTTP_200_OK)
 
 
-# TODO: Profile - User 정보 수정 관련 구현
-# class UpdateUserInfoView(generics.UpdateAPIView):
-#     queryset = CustomUser.objects.all()
-#     serializer_class = UserRegisterSerializer
-#     permission_classes = [permissions.IsAuthenticated]  # 로그인한 사용자만 가능
-
-#     def get_object(self):
-#         # 현재 로그인한 유저의 정보를 업데이트
-#         return self.request.user
-
-#     def update(self, request, *args, **kwargs):
-#         partial = kwargs.pop('partial', False)
-#         instance = self.get_object()
-#         serializer = self.get_serializer(instance, data=request.data, partial=partial)
-#         serializer.is_valid(raise_exception=True)
-#         self.perform_update(serializer)
-
-#         return Response(serializer.data)
-
-
-# class GetUserInfoView(generics.RetrieveAPIView):
-#     queryset = CustomUser.objects.all()
-#     serializer_class = UserRegisterSerializer
-#     permission_classes = [permissions.IsAuthenticated]  # 로그인한 사용자만 가능
-
-#     def get_object(self):
-#         # 현재 로그인한 유저 정보를 반환
-#         return self.request.user
-
-
 @ProfileSchema.my_profile_schema_view
 class MyProfileAPIView(APIView):
     permission_classes = [IsAuthenticated]

--- a/repo/profiles/views.py
+++ b/repo/profiles/views.py
@@ -608,7 +608,7 @@ class PrefFlavorAPIView(APIView):
             return Response({"top_flavors": []})
 
         flavors = records.values_list("taste_review__flavor", flat=True)
-        top_flavors = self.bean_service.get_flavor_percentages(flavors)
+        top_flavors = self.bean_service.get_flavor_percentages(flavors, limit=5)
 
         serializer = PrefFlavorSerializer(data={"top_flavors": top_flavors})
         serializer.is_valid(raise_exception=True)


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용
## **주요 변경 사항**

### **1. 코드 재사용성 강화**

- BeanService 클래스에 get_flavor_percentages 정적 메서드 추가
- 여러 곳에서 중복 사용되던 맛(flavor) 백분율 계산 로직을 통합
- 재사용 가능한 메서드로 구현하여 일관성 있는 처리 가능

### **2. 중복 코드 제거**

- BeanDetailView.get_top_flavors() 메서드 제거
- PrefFlavorAPIView에서 직접 구현하던 계산 로직 제거
- 두 곳 모두 BeanService.get_flavor_percentages 메서드로 대체

### **3. 코드 정리**

- 불필요한 imports 제거 (collections.Counter, itertools.chain)
- 사용하지 않는 주석 코드 정리 (UpdateUserInfoView, GetUserInfoView)

### **4. 데이터 처리 개선**

- 쉼표(,)로 구분된 맛 정보와 원산지 정보를 올바르게 분리 처리
- 백분율 합계가 100%가 되도록 조정 로직 추가

### **5. 의존성 주입 개선**

- BeanDetailView와 PrefFlavorAPIView에 __init__ 메서드 추가
- 서비스 객체를 초기화하여 더 나은 의존성 관리

### **6. 원산지 데이터 처리 표준화**

- PrefCountryAPIView에서 원산지 백분율 계산 로직을 flavor 처리와 유사한 방식으로 개선